### PR TITLE
activated HMR and redux devtools

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,3 +14,6 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('root'),
 );
+
+// hot module replacement during development
+if (module.hot) module.hot.accept();

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,5 +1,6 @@
 import { applyMiddleware, createStore } from 'redux';
 import logger from 'redux-logger';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 
 import rootReducer from './rootReducer';
 
@@ -9,9 +10,8 @@ if (process.env.NODE_ENV === 'development') {
   middlewares.push(logger);
 }
 
-const store = createStore(
-  rootReducer,
+const store = createStore(rootReducer, composeWithDevTools(
   applyMiddleware(...middlewares),
-);
+));
 
 export default store;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,12 @@ module.exports = {
       {
         test: /\.(css|scss|sass)$/,
         use: [
-          MiniCssExtractPlugin.loader,
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              hmr: true
+            }
+          },
           {
             loader: 'css-loader',
           },


### PR DESCRIPTION
There isn't a ticket for this, but while I was working on a different ticket I noticed that hot module replacement wasn't working. (We were getting full page reloads for `.jsx` changes, and `.scss` changes weren't being detected at all.) 

Also, I activated the awesome redux devtools extension, which had been installed but not active yet.