### PR TITLE
live data for charts

### DIFF
--- a/src/components/PinMap/PinMap.jsx
+++ b/src/components/PinMap/PinMap.jsx
@@ -225,7 +225,7 @@ class PinMap extends Component {
 }
 
 const mapStateToProps = state => ({
-  data: state.data.data,
+  data: state.data.pins,
 });
 
 PinMap.propTypes = {

--- a/src/components/Visualizations/Contact311.jsx
+++ b/src/components/Visualizations/Contact311.jsx
@@ -85,7 +85,7 @@ const Contact311 = () => {
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.data.requestTypes,
+  requestTypes: state.filters.requestTypes,
 });
 
 export default connect(mapStateToProps)(Contact311);

--- a/src/components/Visualizations/Contact311.jsx
+++ b/src/components/Visualizations/Contact311.jsx
@@ -1,95 +1,38 @@
 import React from 'react';
 import PropTypes from 'proptypes';
 import { connect } from 'react-redux';
-import Chart from './Chart';
+import { REQUEST_SOURCES } from '@components/common/CONSTANTS';
+import PieChart from './PieChart';
 
-const Contact311 = () => {
-  // // DATA ////
-
-  const randomInt = () => {
-    const min = 10;
-    const max = 100;
-    return Math.round(Math.random() * (max - min) + min);
-  };
-
-  const dummyData = [{
-    label: 'Mobile App',
-    color: '#1D66F2',
-    value: randomInt(),
-  }, {
-    label: 'Call',
-    color: '#D8E5FF',
-    value: randomInt(),
-  }, {
-    label: 'Email',
-    color: '#708ABD',
-    value: randomInt(),
-  }, {
-    label: 'Driver Self Report',
-    color: '#C4C6C9',
-    value: randomInt(),
-  }, {
-    label: 'Self Service',
-    color: '#0C2A64',
-    value: randomInt(),
-  }, {
-    label: 'Other',
-    color: '#6A98F1',
-    value: randomInt(),
-  }];
-
-  const total = dummyData.reduce((p, c) => p + c.value, 0);
-
-  const chartData = {
-    labels: dummyData.map(el => el.label),
-    datasets: [{
-      data: dummyData.map(el => el.value),
-      backgroundColor: dummyData.map(el => el.color),
-      datalabels: {
-        labels: {
-          index: {
-            align: 'end',
-            anchor: 'end',
-            formatter: (value, ctx) => {
-              const { label } = dummyData[ctx.dataIndex];
-              const percentage = (100 * (value / total)).toFixed(1);
-              return `${label}\n${percentage}%`;
-            },
-            offset: 4,
-          },
-        },
-      },
-    }],
-  };
-
-  // // OPTIONS ////
-
-  const chartOptions = {
-    aspectRatio: 1.0,
-    animation: false,
-    layout: {
-      padding: 65,
-    },
-  };
+const Contact311 = ({
+  sourceCounts,
+}) => {
+  const sectors = Object.keys(sourceCounts).map(key => ({
+    label: key,
+    value: sourceCounts[key],
+    color: REQUEST_SOURCES.find(s => s.type === key)?.color,
+  }));
 
   return (
-    <Chart
+    <PieChart
       title="How People Contact 311"
-      type="pie"
-      data={chartData}
-      options={chartOptions}
-      datalabels
+      sectors={sectors}
       className="contact-311"
+      addLabels
     />
   );
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.filters.requestTypes,
+  sourceCounts: state.data.counts.source,
 });
 
 export default connect(mapStateToProps)(Contact311);
 
 Contact311.propTypes = {
-  requestTypes: PropTypes.shape({}).isRequired,
+  sourceCounts: PropTypes.shape({}),
+};
+
+Contact311.defaultProps = {
+  sourceCounts: {},
 };

--- a/src/components/Visualizations/Criteria.jsx
+++ b/src/components/Visualizations/Criteria.jsx
@@ -37,9 +37,9 @@ const Criteria = ({
 };
 
 const mapStateToProps = state => ({
-  startDate: state.data.startDate,
-  endDate: state.data.endDate,
-  councils: state.data.councils,
+  startDate: state.filters.startDate,
+  endDate: state.filters.endDate,
+  councils: state.filters.councils,
 });
 
 export default connect(mapStateToProps)(Criteria);

--- a/src/components/Visualizations/Criteria.jsx
+++ b/src/components/Visualizations/Criteria.jsx
@@ -47,7 +47,7 @@ export default connect(mapStateToProps)(Criteria);
 Criteria.propTypes = {
   startDate: PropTypes.string,
   endDate: PropTypes.string,
-  councils: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  councils: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 Criteria.defaultProps = {

--- a/src/components/Visualizations/Frequency.jsx
+++ b/src/components/Visualizations/Frequency.jsx
@@ -82,7 +82,7 @@ const Frequency = ({
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.data.requestTypes,
+  requestTypes: state.filters.requestTypes,
 });
 
 export default connect(mapStateToProps)(Frequency);

--- a/src/components/Visualizations/Legend.jsx
+++ b/src/components/Visualizations/Legend.jsx
@@ -42,7 +42,7 @@ const Legend = ({
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.data.requestTypes,
+  requestTypes: state.filters.requestTypes,
 });
 
 export default connect(mapStateToProps)(Legend);

--- a/src/components/Visualizations/NumberOfRequests.jsx
+++ b/src/components/Visualizations/NumberOfRequests.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'proptypes';
 
 function addCommas(num) {
@@ -18,12 +19,16 @@ const NumberOfRequests = ({
   </div>
 );
 
-export default NumberOfRequests;
+const mapStateToProps = state => ({
+  numRequests: state.data.pins.length,
+});
+
+export default connect(mapStateToProps)(NumberOfRequests);
 
 NumberOfRequests.propTypes = {
   numRequests: PropTypes.number,
 };
 
 NumberOfRequests.defaultProps = {
-  numRequests: 1285203, // until we get data
+  numRequests: 0,
 };

--- a/src/components/Visualizations/PieChart.jsx
+++ b/src/components/Visualizations/PieChart.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'proptypes';
+import Chart from './Chart';
+
+const PieChart = ({
+  sectors,
+  title,
+  className,
+  addLabels,
+}) => {
+  // // SET ORDER OF SECTORS ////
+  // This weird code goes a long way towards ensuring that the sectors
+  // of the pie chart alternate between big and small sectors, so that
+  // the labels don't overlap each other. It's basically a hack around
+  // the fact that ChartJS puts the sectors in alphabetical order by label.
+
+  // sort sectors by value
+  const sortedSectors = [...sectors].sort((a, b) => b.value - a.value);
+
+  // construct sectors that alternate by size
+  const altSectors = [];
+  for (let i = 0; i < sectors.length; i += 1) {
+    altSectors.push(sortedSectors.shift());
+    sortedSectors.reverse();
+  }
+
+  // add a character to the beginning of each label to trick ChartJS
+  for (let i = 0; i < altSectors.length; i += 1) {
+    altSectors[i].label = String.fromCharCode(65 + i) + altSectors[i].label;
+  }
+
+  // // DATA ////
+
+  const total = altSectors.reduce((p, c) => p + c.value, 0);
+
+  const chartData = {
+    labels: altSectors.map(el => el.label),
+    datasets: [{
+      data: altSectors.map(el => el.value),
+      backgroundColor: altSectors.map(el => el.color),
+      datalabels: {
+        labels: {
+          index: {
+            align: 'end',
+            anchor: 'end',
+            formatter: (value, ctx) => {
+              const { label } = altSectors[ctx.dataIndex];
+              const percentage = (100 * (value / total)).toFixed(1);
+              return addLabels
+                ? `${label.substring(1)}\n${percentage}%`
+                : `${percentage}%`;
+            },
+            offset: 4,
+          },
+        },
+      },
+    }],
+  };
+
+  // // OPTIONS ////
+
+  const chartOptions = {
+    aspectRatio: 1.0,
+    animation: false,
+    layout: {
+      padding: 65,
+    },
+    tooltips: {
+      callbacks: {
+        label: (tt, data) => {
+          const { index } = tt;
+          const label = data.labels[index].substring(1);
+          const value = data.datasets[0].data[index];
+          return ` ${label}: ${value}`;
+        },
+      },
+    },
+  };
+
+  return (
+    <Chart
+      title={title}
+      type="pie"
+      data={chartData}
+      options={chartOptions}
+      datalabels
+      className={className}
+    />
+  );
+};
+
+export default PieChart;
+
+PieChart.propTypes = {
+  sectors: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.number,
+    color: PropTypes.string,
+  })).isRequired,
+  title: PropTypes.string,
+  className: PropTypes.string,
+  addLabels: PropTypes.bool,
+};
+
+PieChart.defaultProps = {
+  title: null,
+  className: undefined,
+  addLabels: false,
+};

--- a/src/components/Visualizations/TimeToClose.jsx
+++ b/src/components/Visualizations/TimeToClose.jsx
@@ -78,7 +78,7 @@ const TimeToClose = ({
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.data.requestTypes,
+  requestTypes: state.filters.requestTypes,
 });
 
 export default connect(mapStateToProps)(TimeToClose);

--- a/src/components/Visualizations/TotalRequests.jsx
+++ b/src/components/Visualizations/TotalRequests.jsx
@@ -87,7 +87,7 @@ const TotalRequests = ({
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.data.requestTypes,
+  requestTypes: state.filters.requestTypes,
 });
 
 export default connect(mapStateToProps)(TotalRequests);

--- a/src/components/Visualizations/TypeOfRequest.jsx
+++ b/src/components/Visualizations/TypeOfRequest.jsx
@@ -2,71 +2,36 @@ import React from 'react';
 import PropTypes from 'proptypes';
 import { connect } from 'react-redux';
 import { REQUEST_TYPES } from '@components/common/CONSTANTS';
-import Chart from './Chart';
+import PieChart from './PieChart';
 
 const TypeOfRequest = ({
-  requestTypes,
+  typeCounts,
 }) => {
-  // // DATA ////
-
-  const randomSeries = (count, min, max) => Array.from({ length: count })
-    .map(() => Math.round(Math.random() * (max - min) + min));
-
-  const selectedTypes = REQUEST_TYPES.filter(el => requestTypes[el.type]);
-
-  const data = randomSeries(selectedTypes.length, 0, 300);
-
-  const total = data.reduce((p, c) => p + c, 0);
-
-  const chartData = {
-    labels: selectedTypes.map(t => t.abbrev),
-    datasets: [{
-      data,
-      backgroundColor: selectedTypes.map(t => t.color),
-      datalabels: {
-        labels: {
-          index: {
-            align: 'end',
-            anchor: 'end',
-            formatter: value => {
-              const percentage = (100 * (value / total)).toFixed(1);
-              return `${percentage}%`;
-            },
-            offset: 12,
-          },
-        },
-      },
-    }],
-  };
-
-  // // OPTIONS ////
-
-  const chartOptions = {
-    aspectRatio: 1.0,
-    animation: false,
-    layout: {
-      padding: 65,
-    },
-  };
+  const sectors = Object.keys(typeCounts).map(key => ({
+    label: key,
+    value: typeCounts[key],
+    color: REQUEST_TYPES.find(t => t.type === key)?.color,
+  }));
 
   return (
-    <Chart
+    <PieChart
       title="Type of Request"
-      type="pie"
-      data={chartData}
-      options={chartOptions}
-      datalabels
+      sectors={sectors}
       className="type-of-request"
     />
   );
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.filters.requestTypes,
+  typeCounts: state.data.counts.type,
 });
 
 export default connect(mapStateToProps)(TypeOfRequest);
 
 TypeOfRequest.propTypes = {
-  requestTypes: PropTypes.shape({}).isRequired,
+  typeCounts: PropTypes.shape({}),
+};
+
+TypeOfRequest.defaultProps = {
+  typeCounts: {},
 };

--- a/src/components/Visualizations/TypeOfRequest.jsx
+++ b/src/components/Visualizations/TypeOfRequest.jsx
@@ -62,7 +62,7 @@ const TypeOfRequest = ({
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.data.requestTypes,
+  requestTypes: state.filters.requestTypes,
 });
 
 export default connect(mapStateToProps)(TypeOfRequest);

--- a/src/components/common/CONSTANTS.js
+++ b/src/components/common/CONSTANTS.js
@@ -86,6 +86,33 @@ export const REQUEST_TYPES = [
    */
 ];
 
+export const REQUEST_SOURCES = [
+  {
+    type: 'Mobile App',
+    color: '#1D66F2',
+  },
+  {
+    type: 'Call',
+    color: '#D8E5FF',
+  },
+  {
+    type: 'Email',
+    color: '#708ABD',
+  },
+  {
+    type: 'Driver Self Report',
+    color: '#C4C6C9',
+  },
+  {
+    type: 'Self Service',
+    color: '#0C2A64',
+  },
+  {
+    type: 'Other',
+    color: '#6A98F1',
+  },
+];
+
 export const REQUESTS = [
   'Bulky Items',
   'Dead Animal Removal',

--- a/src/components/main/footer/Footer.jsx
+++ b/src/components/main/footer/Footer.jsx
@@ -30,7 +30,7 @@ const Footer = ({
         <p style={footerTextStyle}>
           Data Updated Through:
           &nbsp;
-          {lastUpdated && moment(lastUpdated).format('MMMM Do YYYY, h:mm:ss a')}
+          {lastUpdated && moment(1000 * lastUpdated).format('MMMM Do YYYY, h:mm:ss a')}
         </p>
       </div>
     </div>
@@ -42,7 +42,7 @@ const mapStateToProps = state => ({
 });
 
 Footer.propTypes = {
-  lastUpdated: propTypes.string,
+  lastUpdated: propTypes.number,
 };
 
 Footer.defaultProps = {

--- a/src/components/main/menu/DateSelector/DateRangePicker.jsx
+++ b/src/components/main/menu/DateSelector/DateRangePicker.jsx
@@ -7,7 +7,7 @@ import DatePicker from 'react-datepicker';
 import {
   updateStartDate,
   updateEndDate,
-} from '../../../../redux/reducers/data';
+} from '../../../../redux/reducers/filters';
 
 import Button from '../../../common/Button';
 import Icon from '../../../common/Icon';

--- a/src/components/main/menu/DateSelector/DateSelector.jsx
+++ b/src/components/main/menu/DateSelector/DateSelector.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import {
   updateStartDate,
   updateEndDate,
-} from '../../../../redux/reducers/data';
+} from '../../../../redux/reducers/filters';
 
 import Dropdown from '../../../common/Dropdown';
 import Modal from '../../../common/Modal';
@@ -145,8 +145,8 @@ const DateSelector = ({
 };
 
 const mapStateToProps = state => ({
-  startDate: state.data.startDate,
-  endDate: state.data.endDate,
+  startDate: state.filters.startDate,
+  endDate: state.filters.endDate,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/main/menu/Menu.jsx
+++ b/src/components/main/menu/Menu.jsx
@@ -36,7 +36,7 @@ const Menu = ({
           <a
             key={tab}
             className={clx('menu-tab', { active: tab === activeTab })}
-            onClick={() => setMenuTab(tab)}
+            onClick={tab === activeTab ? undefined : () => setMenuTab(tab)}
           >
             { tab }
           </a>

--- a/src/components/main/menu/NCSelector.jsx
+++ b/src/components/main/menu/NCSelector.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import propTypes from 'proptypes';
 
-import { updateNC } from '../../../redux/reducers/data';
+import { updateNC } from '../../../redux/reducers/filters';
 
 import { COUNCILS } from '../../common/CONSTANTS';
 import Checkbox from '../../common/Checkbox';

--- a/src/components/main/menu/RequestTypeSelector.jsx
+++ b/src/components/main/menu/RequestTypeSelector.jsx
@@ -5,7 +5,7 @@ import {
   updateRequestType,
   selectAllRequestTypes,
   deselectAllRequestTypes,
-} from '../../../redux/reducers/data';
+} from '../../../redux/reducers/filters';
 
 import Checkbox from '../../common/Checkbox';
 import Icon from '../../common/Icon';
@@ -150,7 +150,7 @@ const RequestTypeSelector = ({
 };
 
 const mapStateToProps = state => ({
-  requestTypes: state.data.requestTypes,
+  requestTypes: state.filters.requestTypes,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/redux/reducers/data.js
+++ b/src/redux/reducers/data.js
@@ -1,42 +1,8 @@
 export const types = {
-  UPDATE_START_DATE: 'UPDATE_START_DATE',
-  UPDATE_END_DATE: 'UPDATE_END_DATE',
-  UPDATE_REQUEST_TYPE: 'UPDATE_REQUEST_TYPE',
-  UPDATE_NEIGHBORHOOD_COUNCIL: 'UPDATE_NEIGHBORHOOD_COUNCIL',
   GET_DATA_REQUEST: 'GET_DATA_REQUEST',
   GET_DATA_SUCCESS: 'GET_DATA_SUCCESS',
   GET_DATA_FAILURE: 'GET_DATA_FAILURE',
-  SELECT_ALL_REQUEST_TYPES: 'SELECT_ALL_REQUEST_TYPES',
-  DESELECT_ALL_REQUEST_TYPES: 'DESELECT_ALL_REQUEST_TYPES',
 };
-
-export const updateStartDate = newStartDate => ({
-  type: types.UPDATE_START_DATE,
-  payload: newStartDate,
-});
-
-export const updateEndDate = newEndDate => ({
-  type: types.UPDATE_END_DATE,
-  payload: newEndDate,
-});
-
-export const updateRequestType = requestTypes => ({
-  type: types.UPDATE_REQUEST_TYPE,
-  payload: requestTypes,
-});
-
-export const selectAllRequestTypes = () => ({
-  type: types.SELECT_ALL_REQUEST_TYPES,
-});
-
-export const deselectAllRequestTypes = () => ({
-  type: types.DESELECT_ALL_REQUEST_TYPES,
-});
-
-export const updateNC = council => ({
-  type: types.UPDATE_NEIGHBORHOOD_COUNCIL,
-  payload: council,
-});
 
 export const getDataRequest = () => ({
   type: types.GET_DATA_REQUEST,
@@ -53,82 +19,14 @@ export const getDataFailure = error => ({
 });
 
 const initialState = {
-  startDate: null,
-  endDate: null,
-  councils: [],
   data: [],
   isLoading: false,
   error: null,
   lastUpdated: null,
-  requestTypes: {
-    All: false,
-    'Dead Animal': false,
-    'Homeless Encampment': false,
-    'Single Streetlight': false,
-    'Multiple Streetlight': false,
-    'Bulky Items': false,
-    'E-Waste': false,
-    'Metal/Household Appliances': false,
-    'Illegal Dumping': false,
-    Graffiti: false,
-    Feedback: false,
-    Other: false,
-  },
-};
-
-const allRequestTypes = {
-  All: true,
-  'Dead Animal': true,
-  'Homeless Encampment': true,
-  'Single Streetlight': true,
-  'Multiple Streetlight': true,
-  'Bulky Items': true,
-  'E-Waste': true,
-  'Metal/Household Appliances': true,
-  'Illegal Dumping': true,
-  Graffiti: true,
-  Feedback: true,
-  Other: true,
 };
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case types.UPDATE_START_DATE: {
-      return {
-        ...state,
-        startDate: action.payload,
-      };
-    }
-    case types.UPDATE_END_DATE: {
-      return {
-        ...state,
-        endDate: action.payload,
-      };
-    }
-    case types.UPDATE_REQUEST_TYPE:
-      return {
-        ...state,
-        requestTypes: {
-          ...state.requestTypes,
-          // Flips boolean value for selected request type
-          [action.payload]: !state.requestTypes[action.payload],
-        },
-      };
-    case types.SELECT_ALL_REQUEST_TYPES:
-      return {
-        ...state,
-        requestTypes: allRequestTypes,
-      };
-    case types.DESELECT_ALL_REQUEST_TYPES:
-      return {
-        ...state,
-        requestTypes: initialState.requestTypes,
-      };
-    case types.UPDATE_NEIGHBORHOOD_COUNCIL:
-      return {
-        ...state,
-        councils: action.payload,
-      };
     case types.GET_DATA_REQUEST:
       return {
         ...state,

--- a/src/redux/reducers/data.js
+++ b/src/redux/reducers/data.js
@@ -19,10 +19,13 @@ export const getDataFailure = error => ({
 });
 
 const initialState = {
-  data: [],
   isLoading: false,
   error: null,
   lastUpdated: null,
+  pins: [],
+  counts: {},
+  frequency: {},
+  timeToClose: {},
 };
 
 export default (state = initialState, action) => {
@@ -33,14 +36,23 @@ export default (state = initialState, action) => {
         isLoading: true,
       };
     case types.GET_DATA_SUCCESS: {
-      const { data, lastPulled: lastUpdated } = action.payload;
+      const {
+        lastUpdated,
+        pins,
+        counts,
+        frequency,
+        timeToClose,
+      } = action.payload;
 
       return {
         ...state,
-        data,
         error: null,
         isLoading: false,
         lastUpdated,
+        pins,
+        counts,
+        frequency,
+        timeToClose,
       };
     }
     case types.GET_DATA_FAILURE: {

--- a/src/redux/reducers/filters.js
+++ b/src/redux/reducers/filters.js
@@ -1,0 +1,114 @@
+export const types = {
+  UPDATE_START_DATE: 'UPDATE_START_DATE',
+  UPDATE_END_DATE: 'UPDATE_END_DATE',
+  UPDATE_REQUEST_TYPE: 'UPDATE_REQUEST_TYPE',
+  UPDATE_NEIGHBORHOOD_COUNCIL: 'UPDATE_NEIGHBORHOOD_COUNCIL',
+  SELECT_ALL_REQUEST_TYPES: 'SELECT_ALL_REQUEST_TYPES',
+  DESELECT_ALL_REQUEST_TYPES: 'DESELECT_ALL_REQUEST_TYPES',
+};
+
+export const updateStartDate = newStartDate => ({
+  type: types.UPDATE_START_DATE,
+  payload: newStartDate,
+});
+
+export const updateEndDate = newEndDate => ({
+  type: types.UPDATE_END_DATE,
+  payload: newEndDate,
+});
+
+export const updateRequestType = requestTypes => ({
+  type: types.UPDATE_REQUEST_TYPE,
+  payload: requestTypes,
+});
+
+export const selectAllRequestTypes = () => ({
+  type: types.SELECT_ALL_REQUEST_TYPES,
+});
+
+export const deselectAllRequestTypes = () => ({
+  type: types.DESELECT_ALL_REQUEST_TYPES,
+});
+
+export const updateNC = council => ({
+  type: types.UPDATE_NEIGHBORHOOD_COUNCIL,
+  payload: council,
+});
+
+const initialState = {
+  startDate: null,
+  endDate: null,
+  councils: [],
+  requestTypes: {
+    All: false,
+    'Dead Animal': false,
+    'Homeless Encampment': false,
+    'Single Streetlight': false,
+    'Multiple Streetlight': false,
+    'Bulky Items': false,
+    'E-Waste': false,
+    'Metal/Household Appliances': false,
+    'Illegal Dumping': false,
+    Graffiti: false,
+    Feedback: false,
+    Other: false,
+  },
+};
+
+const allRequestTypes = {
+  All: true,
+  'Dead Animal': true,
+  'Homeless Encampment': true,
+  'Single Streetlight': true,
+  'Multiple Streetlight': true,
+  'Bulky Items': true,
+  'E-Waste': true,
+  'Metal/Household Appliances': true,
+  'Illegal Dumping': true,
+  Graffiti: true,
+  Feedback: true,
+  Other: true,
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case types.UPDATE_START_DATE: {
+      return {
+        ...state,
+        startDate: action.payload,
+      };
+    }
+    case types.UPDATE_END_DATE: {
+      return {
+        ...state,
+        endDate: action.payload,
+      };
+    }
+    case types.UPDATE_REQUEST_TYPE:
+      return {
+        ...state,
+        requestTypes: {
+          ...state.requestTypes,
+          // Flips boolean value for selected request type
+          [action.payload]: !state.requestTypes[action.payload],
+        },
+      };
+    case types.SELECT_ALL_REQUEST_TYPES:
+      return {
+        ...state,
+        requestTypes: allRequestTypes,
+      };
+    case types.DESELECT_ALL_REQUEST_TYPES:
+      return {
+        ...state,
+        requestTypes: initialState.requestTypes,
+      };
+    case types.UPDATE_NEIGHBORHOOD_COUNCIL:
+      return {
+        ...state,
+        councils: action.payload,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/redux/rootReducer.js
+++ b/src/redux/rootReducer.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import data from './reducers/data';
+import filters from './reducers/filters';
 import ui from './reducers/ui';
 
 export default combineReducers({
   data,
+  filters,
   ui,
 });

--- a/src/redux/rootSaga.js
+++ b/src/redux/rootSaga.js
@@ -13,7 +13,7 @@ import {
 
 /* /////////// INDIVIDUAL API CALLS /////////// */
 
-const BASE_URL = `https://${process.env.DB_URL}`;
+const BASE_URL = process.env.DB_URL;
 
 async function getPins(filters) {
   const pinUrl = `${BASE_URL}/pins`;

--- a/src/redux/rootSaga.js
+++ b/src/redux/rootSaga.js
@@ -20,7 +20,7 @@ function* getData() {
     endDate,
     councils,
     requestTypes,
-  } = yield select(getState, 'data');
+  } = yield select(getState, 'filters');
 
   const options = {
     startDate,

--- a/src/redux/rootSaga.js
+++ b/src/redux/rootSaga.js
@@ -4,6 +4,7 @@ import {
   call,
   put,
   select,
+  all,
 } from 'redux-saga/effects';
 import {
   types,
@@ -15,10 +16,10 @@ import {
 
 const BASE_URL = process.env.DB_URL;
 
-async function getPins(filters) {
+function* getPins(filters) {
   const pinUrl = `${BASE_URL}/pins`;
 
-  const { data: { lastPulled, data } } = await axios.post(pinUrl, filters);
+  const { data: { lastPulled, data } } = yield call(axios.post, pinUrl, filters);
 
   return {
     lastUpdated: lastPulled,
@@ -26,10 +27,10 @@ async function getPins(filters) {
   };
 }
 
-async function getCounts(filters) {
+function* getCounts(filters) {
   const countsUrl = `${BASE_URL}/requestcounts`;
 
-  const { data: { data } } = await axios.post(countsUrl, {
+  const { data: { data } } = yield call(axios.post, countsUrl, {
     ...filters,
     countFields: ['requesttype', 'requestsource'],
   });
@@ -40,35 +41,36 @@ async function getCounts(filters) {
   };
 }
 
-async function getFrequency() {
-  return {};
+function* getFrequency() {
+  return yield {};
 }
 
-async function getTimeToClose() {
-  return {};
+function* getTimeToClose() {
+  return yield {};
 }
 
 /* //////////// COMBINED API CALL //////////// */
 
-function getAll(filters) {
-  return Promise.all([
-    getPins(filters),
-    getCounts(filters),
-    getFrequency(filters),
-    getTimeToClose(filters),
-  ])
-    .then(([
-      { lastUpdated, pins },
-      counts,
-      frequency,
-      timeToClose,
-    ]) => ({
-      lastUpdated,
-      pins,
-      counts,
-      frequency,
-      timeToClose,
-    }));
+function* getAll(filters) {
+  const [
+    { lastUpdated, pins },
+    counts,
+    frequency,
+    timeToClose,
+  ] = yield all([
+    call(getPins, filters),
+    call(getCounts, filters),
+    call(getFrequency, filters),
+    call(getTimeToClose, filters),
+  ]);
+
+  return {
+    lastUpdated,
+    pins,
+    counts,
+    frequency,
+    timeToClose,
+  };
 }
 
 /* ////////////////// FILTERS //////////////// */


### PR DESCRIPTION
This connects the pie charts and the NumberOfRequests component to real data, and stubs out the data connection for the other charts as well (Time To Close, Frequency, Total Requests). 

To lay the groundwork for that, I moved the filters -- startDate, endDate, councils, requestTypes -- into their own reducer so that the data reducer would be cleaner. The data reducer now holds data for the map and all of the charts, plus error, lastUpdated, and isLoading. 

This request also includes some minor fixes to the Menu, Footer, and Criteria components.

Also, in order to make local dev easier, the api calls now assume that the DB_URL environment variable includes the scheme. So in the .`env` file:

DB_URL=https://hackforla-311-data.herokuapp.com

If you need to switch to the local database, you can just change that to:

DB_URL=http://localhost:5000


