### PR TITLE
Reverted react-leaflet-markercluster dependency to @next version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-leaflet-choropleth": "^2.0.0",
     "react-leaflet-easyprint": "^2.0.0",
     "react-leaflet-heatmap-layer": "^2.0.0",
-    "react-leaflet-markercluster": "^2.0.0",
+    "react-leaflet-markercluster": "^2.0.0-rc3",
     "react-redux": "^7.1.3",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/src/components/main/menu/DistrictSelector/DistrictSelector.jsx
+++ b/src/components/main/menu/DistrictSelector/DistrictSelector.jsx
@@ -33,7 +33,7 @@ const DistrictSelector = ({
   const renderSet = set => {
     const renderHeader = type => {
       const [header] = DISTRICT_TYPES.filter(district => district.id === type);
-      return header.name;
+      return `${header.name} (Set ${set.charAt(set.length - 1)}):`;
     };
 
     if (comparison[set]?.district && comparison[set]?.list.length > 0) {
@@ -42,7 +42,6 @@ const DistrictSelector = ({
           <div className={set}>
             <span className="comparison-set-header">
               {renderHeader(comparison[set].district)}
-              :
             </span>
             <br />
             <CollapsibleList


### PR DESCRIPTION
A recent PR reverted `react-leaflet-markercluster`dependency from v2.0.0-rc3 to 2.0.0. This ended up breaking the map since we're using `react-leaflet` v2.6.1. Back to `react-leaflet-markercluster` v2.0.0-rc3 which is required for `react-leaflet` v2.0.0 and on.

Edit: Also added 'Set 1' and 'Set 2' to the DistrictSelector labels to match #519 