### PR TITLE
Heatmap gradient legend, updated dropdowns

### DIFF
--- a/src/components/PinMap/PinMap.jsx
+++ b/src/components/PinMap/PinMap.jsx
@@ -296,6 +296,17 @@ class PinMap extends Component {
             if (link) link.click();
           }}
         />
+        <div className="heatmap-legend-wrapper has-text-centered">
+          Concentration of Reports (Heatmap)
+          <div id="heatmap-gradient-legend" className="level">
+            <span className="level-left">
+              Low
+            </span>
+            <span className="level-right">
+              High
+            </span>
+          </div>
+        </div>
       </>
     );
   }

--- a/src/components/common/Checkbox.jsx
+++ b/src/components/common/Checkbox.jsx
@@ -11,6 +11,7 @@ const Checkbox = ({
   value,
   checked,
   style,
+  tabbable,
   /*
    *  Props below correspond with Bulma modifiers.
    *  wikiki.github.io/form/checkradio/
@@ -48,8 +49,12 @@ const Checkbox = ({
         className={checkboxClassName}
         checked={checked}
         disabled={disabled}
+        tabIndex={tabbable ? 0 : -1}
       />
-      <label htmlFor={checkboxId} style={style}>
+      <label
+        htmlFor={checkboxId}
+        style={style}
+      >
         {label}
       </label>
     </>
@@ -67,6 +72,7 @@ Checkbox.propTypes = {
   value: PropTypes.string,
   checked: PropTypes.bool,
   style: PropTypes.shape({}),
+  tabbable: PropTypes.bool,
   rightToLeft: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.oneOf(['small', '', 'medium', 'large']),
@@ -85,6 +91,7 @@ Checkbox.defaultProps = {
   value: undefined,
   checked: false,
   style: undefined,
+  tabbable: true,
   rightToLeft: false,
   color: 'primary',
   size: '',

--- a/src/components/common/DropdownItem.jsx
+++ b/src/components/common/DropdownItem.jsx
@@ -24,15 +24,8 @@ const DropdownItem = ({
       onClickCapture={handleClick}
       style={{ width, paddingRight: '0rem' }}
     >
-      <span id="dropdown-item-label">
+      <span className="dropdown-item-label">
         {label}
-      </span>
-      <span style={{ position: 'absolute', right: '0' }}>
-        <Checkbox
-          id={`dd-chkbx-${label}`}
-          checked={active}
-          circle
-        />
       </span>
     </a>
   );

--- a/src/components/common/DropdownItem.jsx
+++ b/src/components/common/DropdownItem.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'proptypes';
 import classNames from 'classnames';
-import Checkbox from './Checkbox';
 
 const DropdownItem = ({
   label,

--- a/src/styles/common/_dropdown.scss
+++ b/src/styles/common/_dropdown.scss
@@ -1,0 +1,7 @@
+.dropdown-content {
+  .dropdown-item {
+    &:hover {
+      background-color: #e0e0e0;
+    }
+  }
+}

--- a/src/styles/map/_map.scss
+++ b/src/styles/map/_map.scss
@@ -13,6 +13,25 @@
     z-index: $z-map-export-button;
     height: auto;
   }
+
+  .heatmap-legend-wrapper {
+    z-index: $z-map-export-button;
+    position: absolute;
+    right: 10px;
+    bottom: 150px;
+    font-size: 12px;
+    font-weight: 600;
+
+    #heatmap-gradient-legend {
+      background: linear-gradient(90deg, blue 10%, cyan 25%, lime 45%, yellow 65%, red 100%);
+      width: 218px;
+      height: 35px;
+      color: white;
+      padding-left: 5px;
+      padding-right: 5px;
+      border-radius: 3px;
+    }
+  }
 }
 
 @import '~react-leaflet-markercluster/dist/styles.min.css';

--- a/src/styles/menu/_districtSelector.scss
+++ b/src/styles/menu/_districtSelector.scss
@@ -48,7 +48,7 @@
 }
 
 .district-selector-dropdown{
-  #dropdown-item-label {
+  .dropdown-item-label {
     font: $brand-text-family;
     font-size: 16px;
   }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -7,6 +7,7 @@
 @import './common/tooltip';
 @import './common/loader';
 @import './common/collapsibleList';
+@import './common/dropdown';
 
 @import './main/header';
 @import './main/body';


### PR DESCRIPTION
Fixes #503 (partially)

- Added heatmap color gradient legend to map. Unfortunately, it always shows even when the heatmap overlay is not selected. It was more complicated than expected to add it just to the heatmap layer.
- Gradient legend was placed above the layers control in the bottom right to avoid centering funkiness when the menu is open or closed.
- Color legend for markerclusters is not included since the marker/clustering code will likely be rewritten soon. This will be revisited during rewrite.
- Removed checkboxes from dropdowns per UI team feedback.
- Added `tabbable` prop to Checkbox component in case we need it in the future. Defaults to `true` and sets tabindex to 0, placing it in the logical navigation flow. Tabbable of `false` sets tabindex to -1, meaning it can't be tabbed to focus.
- Added light grey hover color to dropdown items. It previously had no hover color and gave no visual indication a selection was being hovered.

@joycelee Let me know if you see any changes that need to be made for now.

![Screen Shot 2020-04-09 at 5 03 51 PM](https://user-images.githubusercontent.com/40484278/78951354-b5a64300-7a86-11ea-9a05-6ea1066ca138.png)
![Screen Shot 2020-04-09 at 5 14 21 PM](https://user-images.githubusercontent.com/40484278/78951367-bf2fab00-7a86-11ea-9196-7829ddea786c.png)

