### PR TITLE
performance header and api tests

### DIFF
--- a/bin/api-test/index.js
+++ b/bin/api-test/index.js
@@ -27,7 +27,6 @@ function runTest(path, test) {
 				const time = +performance.executionTime;
 				total += time;
 				console.log(`#${idx + 1}: ${time} seconds`);
-				console.log(typeof time);
 			});
 	})
 		.then(() => ({

--- a/bin/api-test/index.js
+++ b/bin/api-test/index.js
@@ -1,0 +1,58 @@
+const dotenv = require('dotenv').config();
+const axios = require('axios');
+const tests = require('./tests');
+
+////////////////// CONFIG /////////////////////
+
+const API_URL = process.env.DB_URL;
+const CALLS_PER_TEST = 5;
+
+////////////////// HELPERS ////////////////////
+
+async function promiseMapSeries(array, cb) {
+	const results = new Array(array.length);
+  for (let i = 0; i < array.length; i++) {
+    results[i] = await cb(array[i], i);
+  }
+  return results;
+}
+
+function runTest(path, test) {
+	console.log(test.description);
+	let total = 0;
+	return promiseMapSeries(Array(CALLS_PER_TEST), (_, idx) => {
+		return axios.post(API_URL + path, test.params)
+			.then(({ headers, data }) => {
+				const performance = JSON.parse(headers['x-performance']);
+				const time = +performance.executionTime;
+				total += time;
+				console.log(`#${idx + 1}: ${time} seconds`);
+				console.log(typeof time);
+			});
+	})
+		.then(() => ({
+			[test.description]: +(total / CALLS_PER_TEST).toFixed(4),
+		}));
+}
+
+function runTests(endpoints) {
+	return promiseMapSeries(endpoints, endpoint => {
+		console.log('\n' + endpoint.path);
+		return promiseMapSeries(endpoint.tests, params => {
+			return runTest(endpoint.path, params)
+		}).then(results => ({
+			path: endpoint.path,
+			executionTimes: results.reduce((p, c) => {
+				p = { ...p, ...c };
+				return p;
+			}, {}),
+		}));
+	});
+}
+
+///////////////////// MAIN /////////////////////
+
+console.log(`\nRunning tests against: ${API_URL}.`)
+runTests(tests).then(results => {
+	console.log('\n' + JSON.stringify(results, null, 2));
+});

--- a/bin/api-test/tests.js
+++ b/bin/api-test/tests.js
@@ -1,0 +1,72 @@
+
+const NC_IDS = [ 2, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 32, 33, 34, 36, 37, 38, 39, 40, 41, 42, 43, 44, 46, 47, 48, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63, 64, 65, 66, 67, 68, 70, 71, 73, 74, 75, 76, 77, 78, 79, 80, 81, 84, 86, 87, 88, 90, 91, 92, 93, 94, 95, 96, 97, 99, 100, 101, 102, 104, 109, 110, 111, 112, 113, 114, 115, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128 ];
+const CD_IDS = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ];
+const REQUEST_TYPES = [ 'Dead Animal Removal', 'Homeless Encampment', 'Single Streetlight Issue', 'Multiple Streetlight Issue', 'Feedback', 'Bulky Items', 'Electronic Waste', 'Metal/Household Appliances', 'Graffiti Removal', 'Illegal Dumping Pickup', 'Other' ];
+
+const small = {
+	description: 'small',
+	params: {
+		startDate: '2019-01-01',
+		endDate: '2019-02-01',
+		ncList: [ 10, 42, 98 ],
+		requestTypes: ['Bulky Items'],
+		countFields: ['requesttype', 'requestsource'],
+	},
+};
+
+const medium = {
+	description: 'medium',
+	params: {
+		startDate: '2019-01-01',
+		endDate: '2019-07-01',
+		ncList: NC_IDS.slice(0, 50),
+		requestTypes: REQUEST_TYPES.slice(0, 7),
+		countFields: ['requesttype', 'requestsource'],
+	},
+};
+
+const large = {
+	description: 'large',
+	params: {
+		startDate: '2019-01-01',
+		endDate: '2020-01-01',
+		ncList: NC_IDS,
+		requestTypes: REQUEST_TYPES,
+		countFields: ['requesttype', 'requestsource'],
+	},
+};
+
+module.exports = [
+	{
+		path: '/pins',
+		tests: [
+			small,
+			medium,
+			large,
+		],
+	},
+	{
+		path: '/timetoclose',
+		tests: [
+			small,
+			medium,
+			large,
+		],
+	},
+	{
+		path: '/requestfrequency',
+		tests: [
+			small,
+			medium,
+			large,
+		],
+	},
+	{
+		path: '/requestcounts',
+		tests: [
+			small,
+			medium,
+			large,
+		],
+	},
+];

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -17,6 +17,8 @@ from services.ingress_service import ingress_service
 from services.sqlIngest import DataHandler
 from services.feedbackService import FeedbackService
 
+from utils.sanic import add_performance_header
+
 app = Sanic(__name__)
 CORS(app)
 compress = Compress()
@@ -49,6 +51,8 @@ def configure_app():
     environment_overrides()
     app.config["STATIC_DIR"] = os.path.join(os.getcwd(), "static")
     os.makedirs(os.path.join(app.config["STATIC_DIR"], "temp"), exist_ok=True)
+    if app.config['Settings']['Server']['Debug']:
+        add_performance_header(app)
 
 
 @app.route('/')

--- a/server/src/utils/profiler.py
+++ b/server/src/utils/profiler.py
@@ -1,0 +1,68 @@
+import logging
+from functools import wraps
+from contextlib import contextmanager
+import cProfile
+import io
+import pstats
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+
+# set up file logger
+logger = logging.getLogger('311.profiler')
+logger.setLevel(logging.DEBUG)
+handler = logging.FileHandler('./static/profiler.log', 'w')
+logger.addHandler(handler)
+
+
+# log sql queries
+event.listen(
+    Engine,
+    'before_cursor_execute',
+    lambda conn, cursor, statement, parameters, context, executemany:
+        logger.info(statement))
+
+
+@contextmanager
+def profiled():
+    """
+    Log detailed stats on code execution time.
+
+    Usage:
+
+        with profiled():
+            # do things
+    """
+    # clear the log
+    with open('./static/profiler.log', 'w'):
+        pass
+
+    pr = cProfile.Profile()
+    pr.enable()
+    yield
+    pr.disable()
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats('cumulative')
+    ps.print_stats()
+    # ps.print_callers()
+    # ps.print_callees()
+    logger.info(s.getvalue())
+
+
+def profiler():
+    """
+    Log detailed stats on code execution time for a function.
+
+    Usage:
+
+        @profiler()
+        def my_func():
+            # do things
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            with profiled():
+                return f(*args, **kwargs)
+        return decorated_function
+    return decorator

--- a/server/src/utils/sanic.py
+++ b/server/src/utils/sanic.py
@@ -1,0 +1,20 @@
+import time
+import json
+
+
+def add_performance_header(sanic_app):
+    """
+    Add a header to sanic responses that contains the number of
+    seconds it took to execute the request.
+    """
+    async def request(req):
+        req.ctx.start = time.perf_counter()
+
+    async def response(req, res):
+        duration = time.perf_counter() - req.ctx.start
+        res.headers['x-performance'] = json.dumps({
+            'executionTime': round(duration, 4)
+        })
+
+    sanic_app.register_middleware(request, attach_to='request')
+    sanic_app.register_middleware(response, attach_to='response')

--- a/server/src/utils/timer.py
+++ b/server/src/utils/timer.py
@@ -1,0 +1,41 @@
+import time
+from contextlib import contextmanager
+from functools import wraps
+
+
+@contextmanager
+def timed(name=None):
+    """
+    Print execution time for a piece of code.
+
+    Usage:
+
+        with timed('mycode'):
+            # do things
+    """
+    start = time.perf_counter()
+    yield
+    duration = time.perf_counter() - start
+    if name is not None:
+        print('{}: {}'.format(name, duration), flush=True)
+    else:
+        print(duration, flush=True)
+
+
+def timer(name=None):
+    """
+    Print execution time for a function.
+
+    Usage:
+
+        @timer('mytimer')
+        def my_func():
+                # do things
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            with timed(name):
+                return f(*args, **kwargs)
+        return decorated_function
+    return decorator


### PR DESCRIPTION
Fixes #529. This sets up some performance tests for the backend so we have a baseline for optimizing response times. 

When the server is running in DEBUG mode, a header is added to the api responses that shows the number of seconds it took for the server to execute the request.

![performance header](https://user-images.githubusercontent.com/9143823/79371662-90438a00-7f09-11ea-9d2a-f74d0cf86910.png)

There's also a node script that runs a series of tests again the api and uses the performance header to calculate average response times for the endpoints. The output looks like this:

```
[
  {
    "path": "/pins",
    "executionTimes": {
      "small": 0.6833,
      "medium": 1.8100,
      "large": 8.0671
    }
  },
  {
    "path": "/timetoclose",
    "executionTimes": {
      "small": 0.6720,
      "medium": 1.6283,
      "large": 8.9766
    }
  },
  {
    "path": "/requestfrequency",
    "executionTimes": {
      "small": 0.5536,
      "medium": 1.3872,
      "large": 7.3722
    }
  },
  {
    "path": "/requestcounts",
    "executionTimes": {
      "small": 0.4919,
      "medium": 1.3176,
      "large": 6.725"
    }
  }
]
```
Small, medium, and large refers to the filters passed to the api. A small request is a one month period, one request type, and 3 ncs. Medium is 6 months, 7 request types, 50 ncs. And large is 12 months, all request types, and all ncs.

The times above are from the api running locally on my macbook. 

Also included in the PR are some python utilities for timing and code profiling, which will be useful for optimizing the backend code.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved
