### PR TITLE
moved lastPulled into /apistatus response

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -15,6 +15,7 @@ from services.requestCountsService import RequestCountsService
 from services.requestDetailService import RequestDetailService
 from services.sqlIngest import DataHandler
 from services.feedbackService import FeedbackService
+from services.dataService import DataService
 
 from utils.sanic import add_performance_header
 
@@ -56,9 +57,13 @@ async def healthcheck(request):
         settings['Version']['VER_MINOR'],
         settings['Version']['VER_PATCH'])
 
+    data_worker = DataService(settings)
+    lastPulled = await data_worker.lastPulled()
+
     return json({'currentTime': currentTime,
                  'gitSha': githubSha,
-                 'version': semVersion})
+                 'version': semVersion,
+                 'lastPulled': lastPulled})
 
 
 @app.route('/')

--- a/server/src/services/frequencyService.py
+++ b/server/src/services/frequencyService.py
@@ -52,7 +52,7 @@ class FrequencyService(object):
         data = self.dataAccess.query(fields, filters)
 
         # read into a dataframe and drop the nulls
-        df = pd.DataFrame(data['data'], columns=fields).dropna()
+        df = pd.DataFrame(data, columns=fields).dropna()
 
         # convert bins to float so numpy can use them
         bins_fl = np.array(bins).astype('datetime64[s]').astype('float')
@@ -69,12 +69,10 @@ class FrequencyService(object):
             if item not in counts.keys():
                 counts[item] = [0 for bin in bins][:-1]
 
-        data['data'] = {
+        return {
             'bins': list(bins.astype(str)),
             'counts': counts
         }
-
-        return data
 
     async def get_frequency(self,
                             startDate=None,
@@ -156,16 +154,13 @@ class FrequencyService(object):
         set2data = get_data(set2['district'], set2['list'], bins, start, end)
 
         return {
-            'lastPulled': set1data['lastPulled'],
-            'data': {
-                'bins': set1data['data']['bins'],
-                'set1': {
-                    'district': set1['district'],
-                    'counts': set1data['data']['counts']
-                },
-                'set2': {
-                    'district': set2['district'],
-                    'counts': set2data['data']['counts']
-                }
+            'bins': set1data['bins'],
+            'set1': {
+                'district': set1['district'],
+                'counts': set1data['counts']
+            },
+            'set2': {
+                'district': set2['district'],
+                'counts': set2data['counts']
             }
         }

--- a/server/src/services/pinService.py
+++ b/server/src/services/pinService.py
@@ -13,7 +13,6 @@ class PinService(object):
         """
         Returns the base pin data given times, ncs, and request filters
         {
-          'LastPulled': 'Timestamp',
           'data': [
             {
               'srnumber':'String',

--- a/server/src/services/requestCountsService.py
+++ b/server/src/services/requestCountsService.py
@@ -15,27 +15,24 @@ class RequestCountsService(object):
         For each countField, returns the counts of each distinct value
         in that field, given times, ncs, and request filters.
         E.g. if countsFields is ['requesttype', 'requestsource'], returns:
-        {
-            'lastPulled': 'Timestamp',
-            'data': [
-                {
-                    'field': 'requesttype',
-                    'counts': {
-                        'Graffiti Removal': 'Int',
-                        'Bulky Items': 'Int',
-                        ...
-                    }
-                },
-                {
-                    'field': 'requestsource',
-                    'counts': {
-                        'Mobile App': 'Int',
-                        'Driver Self Report': 'Int',
-                        ...
-                    }
+        [
+            {
+                'field': 'requesttype',
+                'counts': {
+                    'Graffiti Removal': 'Int',
+                    'Bulky Items': 'Int',
+                    ...
                 }
-            ]
-        }
+            },
+            {
+                'field': 'requestsource',
+                'counts': {
+                    'Mobile App': 'Int',
+                    'Driver Self Report': 'Int',
+                    ...
+                }
+            }
+        ]
         """
 
         filters = self.dataAccess.standardFilters(
@@ -53,51 +50,48 @@ class RequestCountsService(object):
 
         """
         {
-            "lastPulled": 1585778153,
-            "data": {
-                "set1": {
-                    "district": "nc",
-                    "data": [
-                        {
-                            "field": "requestsource",
-                            "counts": {
-                                "Call": 48,
-                                "Driver Self Report": 68,
-                                "Mobile App": 41,
-                                "Self Service": 41
-                            }
-                        },
-                        {
-                            "field": "requesttype",
-                            "counts": {
-                                "Bulky Items": 93,
-                                "Graffiti Removal": 105
-                            }
+            "set1": {
+                "district": "nc",
+                "data": [
+                    {
+                        "field": "requestsource",
+                        "counts": {
+                            "Call": 48,
+                            "Driver Self Report": 68,
+                            "Mobile App": 41,
+                            "Self Service": 41
                         }
-                    ]
-                },
-                "set2": {
-                    "district": "cc",
-                    "data": [
-                        {
-                            "field": "requestsource",
-                            "counts": {
-                                "Call": 572,
-                                "Driver Self Report": 279,
-                                "Email": 2,
-                                "Mobile App": 530,
-                                "Self Service": 159
-                            }
-                        },
-                        {
-                            "field": "requesttype",
-                            "counts": {
-                                "Bulky Items": 1053,
-                                "Graffiti Removal": 489
-                            }
+                    },
+                    {
+                        "field": "requesttype",
+                        "counts": {
+                            "Bulky Items": 93,
+                            "Graffiti Removal": 105
                         }
-                    ]
-                }
+                    }
+                ]
+            },
+            "set2": {
+                "district": "cc",
+                "data": [
+                    {
+                        "field": "requestsource",
+                        "counts": {
+                            "Call": 572,
+                            "Driver Self Report": 279,
+                            "Email": 2,
+                            "Mobile App": 530,
+                            "Self Service": 159
+                        }
+                    },
+                    {
+                        "field": "requesttype",
+                        "counts": {
+                            "Bulky Items": 1053,
+                            "Graffiti Removal": 489
+                        }
+                    }
+                ]
             }
         }
         """
@@ -124,15 +118,12 @@ class RequestCountsService(object):
         set2data = self.dataAccess.aggregateQuery(countFields, filters)
 
         return {
-            'lastPulled': set1data['lastPulled'],
-            'data': {
-                'set1': {
-                    'district': set1['district'],
-                    'data': set1data['data']
-                },
-                'set2': {
-                    'district': set2['district'],
-                    'data': set2data['data']
-                }
+            'set1': {
+                'district': set1['district'],
+                'data': set1data
+            },
+            'set2': {
+                'district': set2['district'],
+                'data': set2data
             }
         }

--- a/server/src/services/requestDetailService.py
+++ b/server/src/services/requestDetailService.py
@@ -9,7 +9,6 @@ class RequestDetailService(object):
         """
         Returns all properties tied to a service request given the srNumber
         {
-          'LastPulled': 'Timestamp',
           'data': {
               'ncname':'String',
               'requesttype':'String',

--- a/server/src/services/timeToCloseService.py
+++ b/server/src/services/timeToCloseService.py
@@ -57,7 +57,7 @@ class TimeToCloseService(object):
         data = self.dataAccess.query(fields, filters)
 
         # read into a dataframe and drop the nulls
-        df = pd.DataFrame(data['data'], columns=fields).dropna()
+        df = pd.DataFrame(data, columns=fields).dropna()
 
         # generate a new dataframe that contains the number of days it
         # takes to close each request, plus the type of request
@@ -69,7 +69,7 @@ class TimeToCloseService(object):
         dtc_df = df[[groupField, 'days-to-close']]
 
         # group the requests by type and get box plot stats for each type
-        data['data'] = dtc_df \
+        data = dtc_df \
             .groupby(by=groupField) \
             .apply(lambda df: get_boxplot_stats(df['days-to-close'].values)) \
             .to_dict()
@@ -77,8 +77,8 @@ class TimeToCloseService(object):
         # if no rows exist for a particular item in the groupField,
         # return a count of 0
         for item in groupFieldItems:
-            if item not in data['data'].keys():
-                data['data'][item] = {'count': 0}
+            if item not in data.keys():
+                data[item] = {'count': 0}
 
         return data
 
@@ -93,21 +93,18 @@ class TimeToCloseService(object):
 
         Example response:
         {
-            lastPulled: Timestamp,
-            data: {
-                'Bulky Items': {
-                    'min': float,
-                    'q1': float,
-                    'median': float,
-                    'q3': float,
-                    'max': float,
-                    'whiskerMin': float,
-                    'whiskerMax': float,
-                    'outliers': [float],
-                    'count': int
-                }
-                ...
+            'Bulky Items': {
+                'min': float,
+                'q1': float,
+                'median': float,
+                'q3': float,
+                'max': float,
+                'whiskerMin': float,
+                'whiskerMax': float,
+                'outliers': [float],
+                'count': int
             }
+            ...
         }
         """
 
@@ -129,23 +126,20 @@ class TimeToCloseService(object):
 
         Example response:
         {
-            lastPulled: Timestamp,
-            data: {
-                set1: {
-                    district: 'nc',
-                    data: {
-                        4: { stats },
-                        8: { stats }
-                        ...
-                    }
-                },
-                set2: {
-                    district: 'cc',
-                    data: {
-                        1: { stats },
-                        15: { stats }
-                        ...
-                    }
+            set1: {
+                district: 'nc',
+                data: {
+                    4: { stats },
+                    8: { stats }
+                    ...
+                }
+            },
+            set2: {
+                district: 'cc',
+                data: {
+                    1: { stats },
+                    15: { stats }
+                    ...
                 }
             }
         }
@@ -172,15 +166,12 @@ class TimeToCloseService(object):
         set2data = get_data(set2['district'], set2['list'])
 
         return {
-            'lastPulled': set1data['lastPulled'],
-            'data': {
-                'set1': {
-                    'district': set1['district'],
-                    'data': set1data['data']
-                },
-                'set2': {
-                    'district': set2['district'],
-                    'data': set2data['data']
-                }
+            'set1': {
+                'district': set1['district'],
+                'data': set1data
+            },
+            'set2': {
+                'district': set2['district'],
+                'data': set2data
             }
         }

--- a/src/components/main/footer/Footer.jsx
+++ b/src/components/main/footer/Footer.jsx
@@ -17,11 +17,13 @@ const Footer = ({
       <Switch>
         <Route path="/(about|contact)" component={StaticFooter} />
         <Route path="/">
-          <span className="last-updated">
-            Data Updated Through:
-            &nbsp;
-            {lastUpdated && moment(1000 * lastUpdated).format('MMMM Do YYYY, h:mm:ss a')}
-          </span>
+          { lastUpdated && (
+            <span className="last-updated">
+              Data Updated Through:
+              &nbsp;
+              {moment(1000 * lastUpdated).format('MMMM Do YYYY, h:mm:ss a')}
+            </span>
+          )}
           { version && backendSha && (
             <span className="version">
               <HoverOverInfo
@@ -44,7 +46,7 @@ const Footer = ({
 };
 
 const mapStateToProps = state => ({
-  lastUpdated: state.data.lastUpdated,
+  lastUpdated: state.metadata.lastPulled,
   version: state.metadata.version,
   backendSha: state.metadata.gitSha,
 });

--- a/src/redux/reducers/comparisonData.js
+++ b/src/redux/reducers/comparisonData.js
@@ -21,7 +21,6 @@ export const getComparisonDataFailure = error => ({
 const initialState = {
   isLoading: false,
   error: null,
-  lastUpdated: null,
   chart: null,
   counts: {
     set1: {

--- a/src/redux/reducers/data.js
+++ b/src/redux/reducers/data.js
@@ -57,7 +57,6 @@ export const gitResponseFailure = error => ({
 const initialState = {
   isLoading: false,
   error: null,
-  lastUpdated: null,
   pins: [],
   pinsInfo: {},
   counts: {},

--- a/src/redux/sagas/comparisonData.js
+++ b/src/redux/sagas/comparisonData.js
@@ -25,24 +25,19 @@ const BASE_URL = process.env.DB_URL;
 function* getCountsComparison(filters) {
   const url = `${BASE_URL}/requestcounts-comparison`;
 
-  const { data } = yield call(axios.post, url, {
+  const { data: { set1, set2 } } = yield call(axios.post, url, {
     ...filters,
     countFields: ['requestsource'],
   });
 
-  const { set1, set2 } = data.data;
-
   return {
-    ...data,
-    data: {
-      set1: {
-        district: set1.district,
-        source: set1.data.find(d => d.field === 'requestsource')?.counts,
-      },
-      set2: {
-        district: set2.district,
-        source: set2.data.find(d => d.field === 'requestsource')?.counts,
-      },
+    set1: {
+      district: set1.district,
+      source: set1.data.find(d => d.field === 'requestsource')?.counts,
+    },
+    set2: {
+      district: set2.district,
+      source: set2.data.find(d => d.field === 'requestsource')?.counts,
     },
   };
 }
@@ -68,26 +63,17 @@ function* getFrequencyComparison(filters) {
 function* getChartData(filters) {
   switch (filters.chart) {
     case 'contact': {
-      const data = yield call(getCountsComparison, filters);
-      return {
-        lastUpdated: data.lastPulled,
-        counts: data.data,
-      };
+      const counts = yield call(getCountsComparison, filters);
+      return { counts };
     }
     case 'time': {
-      const data = yield call(getTimeToCloseComparison, filters);
-      return {
-        lastUpdated: data.lastPulled,
-        timeToClose: data.data,
-      };
+      const timeToClose = yield call(getTimeToCloseComparison, filters);
+      return { timeToClose };
     }
     case 'frequency':
     case 'request': {
-      const data = yield call(getFrequencyComparison, filters);
-      return {
-        lastUpdated: data.lastPulled,
-        frequency: data.data,
-      };
+      const frequency = yield call(getFrequencyComparison, filters);
+      return { frequency };
     }
     default:
       return {};

--- a/src/redux/sagas/data.js
+++ b/src/redux/sagas/data.js
@@ -33,18 +33,15 @@ const BASE_URL = process.env.DB_URL;
 function* getPins(filters) {
   const pinUrl = `${BASE_URL}/pins`;
 
-  const { data: { lastPulled, data } } = yield call(axios.post, pinUrl, filters);
+  const { data } = yield call(axios.post, pinUrl, filters);
 
-  return {
-    lastUpdated: lastPulled,
-    pins: data,
-  };
+  return data;
 }
 
 function* getCounts(filters) {
   const countsUrl = `${BASE_URL}/requestcounts`;
 
-  const { data: { data } } = yield call(axios.post, countsUrl, {
+  const { data } = yield call(axios.post, countsUrl, {
     ...filters,
     countFields: ['requesttype', 'requestsource'],
   });
@@ -58,7 +55,7 @@ function* getCounts(filters) {
 function* getFrequency(filters) {
   const frequencyUrl = `${BASE_URL}/requestfrequency`;
 
-  const { data: { data } } = yield call(axios.post, frequencyUrl, filters);
+  const { data } = yield call(axios.post, frequencyUrl, filters);
 
   return data;
 }
@@ -66,7 +63,7 @@ function* getFrequency(filters) {
 function* getTimeToClose(filters) {
   const ttcUrl = `${BASE_URL}/timetoclose`;
 
-  const { data: { data } } = yield call(axios.post, ttcUrl, filters);
+  const { data } = yield call(axios.post, ttcUrl, filters);
 
   return data;
 }
@@ -74,7 +71,7 @@ function* getTimeToClose(filters) {
 function* fetchPinInfo(srnumber) {
   const pinInfoUrl = `${BASE_URL}/servicerequest/${srnumber}`;
 
-  const { data: { data } } = yield call(axios.get, pinInfoUrl);
+  const { data } = yield call(axios.get, pinInfoUrl);
 
   return data;
 }
@@ -90,7 +87,7 @@ function* postFeedback(message) {
 
 function* getAll(filters) {
   const [
-    { lastUpdated, pins },
+    pins,
     counts,
     frequency,
     timeToClose,
@@ -102,7 +99,6 @@ function* getAll(filters) {
   ]);
 
   return {
-    lastUpdated,
     pins,
     counts,
     frequency,


### PR DESCRIPTION
This adds the `lastPulled` time for the DB to the response from `/apistatus`, and removes it from the responses from the other endpoints. The frontend consumes the value when the app loads up and immediately displays it in the footer.

This change will make it easier to refactor/optimize our backend services since they won't have to worry about preserving the `lastPulled` value in all of the responses from the DataService. 

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [x] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
