### PR TITLE
Front/Accessibility: alt text

### DIFF
--- a/src/components/about/HowItWorks.jsx
+++ b/src/components/about/HowItWorks.jsx
@@ -10,10 +10,10 @@ const HowItWorks = () => (
   <div className="how-it-works">
     <h1>How It Works</h1>
     <div className="grid-container">
-      <MobileSVG />
-      <DataServerSVG />
-      <GrowthSVG />
-      <DataVizSVG />
+      <MobileSVG alt="Mobile Telephone" />
+      <DataServerSVG alt="Cloud Database" />
+      <DataVizSVG alt="Laptop Computer Displaying Data Visualizations" />
+      <GrowthSVG alt="Upturned Hand Holding Seedling" />
       <p>Community members post reports via the City&apos;s easy-to-use mobile application.</p>
       <p>
         Reports are consolidated and entered into a central database and requests are

--- a/src/components/about/WhatIs311Data.jsx
+++ b/src/components/about/WhatIs311Data.jsx
@@ -16,10 +16,10 @@ const WhatIs311Data = () => (
     </p>
     <div className="logos level">
       <span className="level-item">
-        <EmpowerLaSVG />
+        <EmpowerLaSVG alt="EmpowerLA Neighborhood Council Logo" />
       </span>
       <span className="level-item">
-        <HackforLaSVG />
+        <HackforLaSVG alt="Hack for LA Logo" />
       </span>
     </div>
     <p>

--- a/src/styles/about/_howitworks.scss
+++ b/src/styles/about/_howitworks.scss
@@ -1,5 +1,5 @@
 .how-it-works{
-  margin: 75px 5em 5em 100px;
+  margin: 75px 15em 5em 15em;
 
   h1 {
     text-align: center;
@@ -15,7 +15,7 @@
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     grid-row-gap: 20px;
-    grid-column-gap: 75px;
+    grid-column-gap: 50px;
     justify-items: center;
   }
 }

--- a/src/styles/about/_whatis311data.scss
+++ b/src/styles/about/_whatis311data.scss
@@ -1,7 +1,7 @@
 .main-text {
   margin-top: 48px;
-  margin-left: 5em;
-  margin-right: 5em;
+  margin-left: 15em;
+  margin-right: 15em;
 
   h1 {
     text-align: center;


### PR DESCRIPTION
Fixes #563 

Tiny PR. Added alt text to images and increased margins on the About page. Did not add alt text to hero images on About/Contact as they're purely aesthetic and don't provide any important info for the user.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved
