### PR TITLE
integration of /pin-clusters

### DIFF
--- a/src/components/PinMap/ClusterMarker.jsx
+++ b/src/components/PinMap/ClusterMarker.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'proptypes';
+import { Marker } from 'react-leaflet';
+import { divIcon, point } from 'leaflet';
+
+function markerClass(count) {
+  if (count < 100) return 'small';
+  if (count < 1000) return 'medium';
+  return 'large';
+}
+
+function abbreviatedCount(count) {
+  if (count < 1000) return count;
+  if (count < 10000) return `${(count / 1000).toFixed(1)}K`;
+  if (count < 1000000) return `${(count / 1000).toFixed(0)}K`;
+  return `${(count / 1000000).toFixed(1)}M`;
+}
+
+const ClusterMarker = ({
+  position,
+  count,
+  onClick,
+}) => {
+  const markerIcon = divIcon({
+    html: `<div><span>${abbreviatedCount(count)}</span></div>`,
+    className: `marker-cluster marker-cluster-${markerClass(count)}`,
+    iconSize: point(40, 40),
+  });
+
+  return (
+    <Marker position={position} onClick={onClick} icon={markerIcon} />
+  );
+};
+
+export default ClusterMarker;
+
+ClusterMarker.propTypes = {
+  position: PropTypes.node.isRequired,
+  count: PropTypes.number.isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/src/components/chartExtras/NumberOfRequests.jsx
+++ b/src/components/chartExtras/NumberOfRequests.jsx
@@ -20,7 +20,7 @@ const NumberOfRequests = ({
 );
 
 const mapStateToProps = state => ({
-  numRequests: state.data.pins.length,
+  numRequests: Object.values(state.data.counts.type).reduce((p, c) => p + c, 0),
 });
 
 export default connect(mapStateToProps)(NumberOfRequests);

--- a/src/components/common/Loader.jsx
+++ b/src/components/common/Loader.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'proptypes';
 import { connect } from 'react-redux';
+import { MENU_TABS } from '@components/common/CONSTANTS';
 
 const Loader = ({
   isLoading,
@@ -17,9 +18,16 @@ const Loader = ({
   );
 };
 
-const mapStateToProps = state => ({
-  isLoading: state.data.isLoading || state.comparisonData.isLoading,
-});
+const mapStateToProps = state => {
+  const { activeTab } = state.ui.menu;
+  return {
+    isLoading: (
+      state.comparisonData.isLoading
+      || (state.data.isMapLoading && activeTab === MENU_TABS.MAP)
+      || (state.data.isVisLoading && activeTab === MENU_TABS.VISUALIZATIONS)
+    ),
+  };
+};
 
 export default connect(mapStateToProps)(Loader);
 

--- a/src/redux/reducers/data.js
+++ b/src/redux/reducers/data.js
@@ -1,10 +1,14 @@
 export const types = {
   GET_DATA_REQUEST: 'GET_DATA_REQUEST',
-  GET_DATA_SUCCESS: 'GET_DATA_SUCCESS',
-  GET_DATA_FAILURE: 'GET_DATA_FAILURE',
   GET_PIN_INFO_REQUEST: 'GET_PIN_INFO_REQUEST',
   GET_PIN_INFO_SUCCESS: 'GET_PIN_INFO_SUCCESS',
   GET_PIN_INFO_FAILURE: 'GET_PIN_INFO_FAILURE',
+  GET_PIN_CLUSTERS_SUCCESS: 'GET_PIN_CLUSTERS_SUCCESS',
+  GET_PIN_CLUSTERS_FAILURE: 'GET_PIN_CLUSTERS_FAILURE',
+  GET_HEATMAP_SUCCESS: 'GET_HEATMAP_SUCCESS',
+  GET_HEATMAP_FAILURE: 'GET_HEATMAP_FAILURE',
+  GET_VIS_DATA_SUCCESS: 'GET_VIS_DATA_SUCCESS',
+  GET_VIS_DATA_FAILURE: 'GET_VIS_DATA_FAILURE',
   SEND_GIT_REQUEST: 'SEND_GIT_REQUEST',
   GIT_RESPONSE_SUCCESS: 'GIT_RESPONSE_SUCCESS',
   GIT_RESPONSE_FAILURE: 'GIT_RESPONSE_FAILURE',
@@ -12,16 +16,6 @@ export const types = {
 
 export const getDataRequest = () => ({
   type: types.GET_DATA_REQUEST,
-});
-
-export const getDataSuccess = response => ({
-  type: types.GET_DATA_SUCCESS,
-  payload: response,
-});
-
-export const getDataFailure = error => ({
-  type: types.GET_DATA_FAILURE,
-  payload: error,
 });
 
 export const getPinInfoRequest = srnumber => ({
@@ -36,6 +30,36 @@ export const getPinInfoSuccess = response => ({
 
 export const getPinInfoFailure = error => ({
   type: types.GET_PIN_INFO_FAILURE,
+  payload: error,
+});
+
+export const getPinClustersSuccess = response => ({
+  type: types.GET_PIN_CLUSTERS_SUCCESS,
+  payload: response,
+});
+
+export const getPinClustersFailure = error => ({
+  type: types.GET_PIN_CLUSTERS_FAILURE,
+  payload: error,
+});
+
+export const getHeatmapSuccess = response => ({
+  type: types.GET_HEATMAP_SUCCESS,
+  payload: response,
+});
+
+export const getHeatmapFailure = error => ({
+  type: types.GET_HEATMAP_FAILURE,
+  payload: error,
+});
+
+export const getVisDataSuccess = response => ({
+  type: types.GET_VIS_DATA_SUCCESS,
+  payload: response,
+});
+
+export const getVisDataFailure = error => ({
+  type: types.GET_VIS_DATA_FAILURE,
   payload: error,
 });
 
@@ -55,9 +79,11 @@ export const gitResponseFailure = error => ({
 });
 
 const initialState = {
-  isLoading: false,
+  isMapLoading: false,
+  isVisLoading: false,
   error: null,
-  pins: [],
+  pinClusters: [],
+  heatmap: [],
   pinsInfo: {},
   counts: {},
   frequency: {
@@ -72,33 +98,9 @@ export default (state = initialState, action) => {
     case types.GET_DATA_REQUEST:
       return {
         ...state,
-        isLoading: true,
+        isMapLoading: true,
+        isVisLoading: true,
       };
-    case types.GET_DATA_SUCCESS:
-      return {
-        ...state,
-        error: null,
-        isLoading: false,
-        ...action.payload,
-      };
-    case types.GET_DATA_FAILURE: {
-      const {
-        response: { status },
-        message,
-      } = action.payload;
-
-      return {
-        ...state,
-        error: {
-          code: status,
-          message,
-          error: action.payload,
-        },
-        isLoading: false,
-      };
-    }
-    case types.GET_PIN_INFO_REQUEST:
-      return state;
     case types.GET_PIN_INFO_SUCCESS:
       return {
         ...state,
@@ -107,7 +109,6 @@ export default (state = initialState, action) => {
           ...state.pinsInfo,
           [action.payload.srnumber]: action.payload,
         },
-        isLoading: false,
       };
     case types.GET_PIN_INFO_FAILURE: {
       const {
@@ -121,19 +122,76 @@ export default (state = initialState, action) => {
           message,
           error: action.payload,
         },
-        isLoading: false,
       };
     }
-    case types.SEND_GIT_REQUEST:
+    case types.GET_PIN_CLUSTERS_SUCCESS:
       return {
         ...state,
-        isLoading: true,
+        error: null,
+        pinClusters: action.payload,
+        isMapLoading: false,
       };
+    case types.GET_PIN_CLUSTERS_FAILURE: {
+      const {
+        response: { status },
+        message,
+      } = action.payload;
+      return {
+        ...state,
+        error: {
+          code: status,
+          message,
+          error: action.payload,
+        },
+        isMapLoading: false,
+      };
+    }
+    case types.GET_HEATMAP_SUCCESS:
+      return {
+        ...state,
+        error: null,
+        heatmap: action.payload,
+      };
+    case types.GET_HEATMAP_FAILURE: {
+      const {
+        response: { status },
+        message,
+      } = action.payload;
+      return {
+        ...state,
+        error: {
+          code: status,
+          message,
+          error: action.payload,
+        },
+      };
+    }
+    case types.GET_VIS_DATA_SUCCESS:
+      return {
+        ...state,
+        error: null,
+        ...action.payload,
+        isVisLoading: false,
+      };
+    case types.GET_VIS_DATA_FAILURE: {
+      const {
+        response: { status },
+        message,
+      } = action.payload;
+      return {
+        ...state,
+        error: {
+          code: status,
+          message,
+          error: action.payload,
+        },
+        isVisLoading: false,
+      };
+    }
     case types.GIT_RESPONSE_SUCCESS:
       return {
         ...state,
         error: null,
-        isLoading: false,
       };
     case types.GIT_RESPONSE_FAILURE: {
       const {
@@ -148,7 +206,6 @@ export default (state = initialState, action) => {
           message,
           error: action.payload,
         },
-        isLoading: false,
       };
     }
     default:

--- a/src/redux/reducers/ui.js
+++ b/src/redux/reducers/ui.js
@@ -1,12 +1,13 @@
 import { MENU_TABS } from '@components/common/CONSTANTS';
 
-const types = {
+export const types = {
   TOGGLE_MENU: 'TOGGLE_MENU',
   SET_MENU_TAB: 'SET_MENU_TAB',
   SET_ERROR_MODAL: 'SET_ERROR_MODAL',
   SHOW_DATA_CHARTS: 'SHOW_DATA_CHARTS',
   SHOW_COMPARISON_CHARTS: 'SHOW_COMPARISON_CHARTS',
   SHOW_FEEDBACK_SUCCESS: 'SHOW_FEEDBACK_SUCCESS',
+  UPDATE_MAP_POSITION: 'UPDATE_MAP_POSITION',
 };
 
 export const toggleMenu = () => ({
@@ -38,11 +39,17 @@ export const showFeedbackSuccess = isShown => ({
   payload: isShown,
 });
 
+export const updateMapPosition = position => ({
+  type: types.UPDATE_MAP_POSITION,
+  payload: position,
+});
+
 const initialState = {
   menu: {
     isOpen: true,
     activeTab: MENU_TABS.MAP,
   },
+  map: {},
   error: {
     isOpen: false,
   },
@@ -91,6 +98,11 @@ export default (state = initialState, action) => {
       return {
         ...state,
         displayFeedbackSuccess: action.payload,
+      };
+    case types.UPDATE_MAP_POSITION:
+      return {
+        ...state,
+        map: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
Fixes #565

This integrates server-side pin clustering into the front end. 

It also decouples the api calls so that the map data requests and the visualizations data requests don't block each other. So if the user is on the Map tab, they will see pin clusters even if the visualizations data isn't back from the server yet (and vice versa if they are on the Visualizations tab). The main logic for that is in the root saga in `sagas/data.js`:

```
export default function* rootSaga() {
  yield takeLatest(types.GET_DATA_REQUEST, getMapData);  <-- independent of vis data
  yield takeLatest(types.GET_DATA_REQUEST, getVisData);  <-- independent of map data
  yield takeLatest(uiTypes.UPDATE_MAP_POSITION, updatePinClusters);
  yield takeEvery(types.GET_PIN_INFO_REQUEST, getPinData);
  yield takeLatest(types.SEND_GIT_REQUEST, sendContactData);
}
```

The `getMapData` function makes two api calls in sequence:
1. `/pin-clusters` -- only the data necessary to render the pin clusters given current zoom and bounds
2. `/heatmap` -- returns an array of lat/longs necessary to generate the heatmap

These are done in sequence rather than in parallel because the `/pin-clusters` request warms up the redis cache for the `/heatmap` request, which will ease the load on the database.


  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [x] Peer reviewed and approved
