### PR TITLE
Fixed data vis error resulting from a query with zero results.

### DIFF
--- a/src/components/chartExtras/NumberOfRequests.jsx
+++ b/src/components/chartExtras/NumberOfRequests.jsx
@@ -20,7 +20,7 @@ const NumberOfRequests = ({
 );
 
 const mapStateToProps = state => ({
-  numRequests: Object.values(state.data.counts.type).reduce((p, c) => p + c, 0),
+  numRequests: Object.values(state.data.counts.type || {}).reduce((p, c) => p + c, 0),
 });
 
 export default connect(mapStateToProps)(NumberOfRequests);


### PR DESCRIPTION
Fixes #590 

Tiny bugfix. 

- `state.data.counts` initial value is an empty object `{}`. 
- After a successful query with greater than 0 records, `state.data.counts` = `{ type: { ...}, source: { ...} }`. 
- After a query returning 0 records, it remains an empty object. 
- As a result, NumberOfRequests throws an error trying to convert `state.data.counts.type` (undefined) to an object. Adding an empty object as the fallback value for `state.data.counts.type` resolved the issue.
