### PR TITLE
reading in pandas/materialized views

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -63,7 +63,7 @@ async def healthcheck(request):
         settings['Version']['VER_MINOR'],
         settings['Version']['VER_PATCH'])
 
-    data_worker = DataService(settings)
+    data_worker = DataService()
     lastPulled = await data_worker.lastPulled()
 
     return json({'currentTime': currentTime,

--- a/server/src/services/dataService.py
+++ b/server/src/services/dataService.py
@@ -78,6 +78,9 @@ class DataService(object):
             return {'Error': 'Request number not found'}
 
     def query(self, fields, filters, table=default_table):
+        if not fields or not filters:
+            return {'Error': 'fields and filters are required'}
+
         fields = (', ').join(fields)
         return pd.read_sql(f"""
             SELECT {fields}

--- a/server/src/services/frequencyService.py
+++ b/server/src/services/frequencyService.py
@@ -49,7 +49,7 @@ class FrequencyService(object):
 
         # grab the necessary data from the db and drop nulls
         fields = [groupField, 'createddate']
-        df = self.dataAccess.query(fields, filters).dropna()
+        df = self.dataAccess.query(fields, filters, table='vis').dropna()
 
         # convert bins to float so numpy can use them
         bins_fl = np.array(bins).astype('datetime64[s]').astype('float')

--- a/server/src/services/frequencyService.py
+++ b/server/src/services/frequencyService.py
@@ -47,12 +47,9 @@ class FrequencyService(object):
             counts, _ = np.histogram(dates, bins=bins)
             return list(map(int, counts))
 
-        # grab the necessary data from the db
+        # grab the necessary data from the db and drop nulls
         fields = [groupField, 'createddate']
-        data = self.dataAccess.query(fields, filters)
-
-        # read into a dataframe and drop the nulls
-        df = pd.DataFrame(data, columns=fields).dropna()
+        df = self.dataAccess.query(fields, filters).dropna()
 
         # convert bins to float so numpy can use them
         bins_fl = np.array(bins).astype('datetime64[s]').astype('float')

--- a/server/src/services/heatmapService.py
+++ b/server/src/services/heatmapService.py
@@ -28,7 +28,7 @@ class HeatmapService(object):
                 filters['requestTypes'],
                 filters['ncList'])
 
-            pins = dataAccess.query(fields, filters)
+            pins = dataAccess.query(fields, filters, table='map')
             pins = pd.DataFrame(pins, columns=fields)
         else:
             pins = pins[fields]

--- a/server/src/services/pinClusterService.py
+++ b/server/src/services/pinClusterService.py
@@ -34,7 +34,7 @@ class PinClusterService(object):
                 filters['requestTypes'],
                 filters['ncList'])
 
-            pins = dataAccess.query(fields, filters)
+            pins = dataAccess.query(fields, filters, table='map')
             pins = pd.DataFrame(pins, columns=fields)
 
             cache.set(key, pins)

--- a/server/src/services/requestCountsService.py
+++ b/server/src/services/requestCountsService.py
@@ -38,7 +38,8 @@ class RequestCountsService(object):
         filters = self.dataAccess.standardFilters(
             startDate, endDate, requestTypes, ncList)
 
-        return self.dataAccess.aggregateQuery(countFields, filters)
+        return self.dataAccess.aggregateQuery(
+            countFields, filters, table='vis')
 
     async def get_req_counts_comparison(self,
                                         startDate=None,
@@ -112,10 +113,12 @@ class RequestCountsService(object):
                 return self.dataAccess.comparisonFilters(**common)
 
         filters = get_filters(set1['district'], set1['list'])
-        set1data = self.dataAccess.aggregateQuery(countFields, filters)
+        set1data = self.dataAccess.aggregateQuery(
+            countFields, filters, table='vis')
 
         filters = get_filters(set2['district'], set2['list'])
-        set2data = self.dataAccess.aggregateQuery(countFields, filters)
+        set2data = self.dataAccess.aggregateQuery(
+            countFields, filters, table='vis')
 
         return {
             'set1': {

--- a/server/src/services/timeToCloseService.py
+++ b/server/src/services/timeToCloseService.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 from .dataService import DataService
 
@@ -52,12 +51,9 @@ class TimeToCloseService(object):
                 'outlierCount': len(outliers)
             }
 
-        # grab the necessary data from the db
+        # grab the necessary data from the db and drop nulls
         fields = [groupField, '_daystoclose']
-        data = self.dataAccess.query(fields, filters)
-
-        # read into a dataframe and drop the nulls
-        dtc_df = pd.DataFrame(data, columns=fields).dropna()
+        dtc_df = self.dataAccess.query(fields, filters).dropna()
 
         # group the requests by type and get box plot stats for each type
         data = dtc_df \

--- a/server/src/services/timeToCloseService.py
+++ b/server/src/services/timeToCloseService.py
@@ -53,7 +53,7 @@ class TimeToCloseService(object):
 
         # grab the necessary data from the db and drop nulls
         fields = [groupField, '_daystoclose']
-        dtc_df = self.dataAccess.query(fields, filters).dropna()
+        dtc_df = self.dataAccess.query(fields, filters, table='vis').dropna()
 
         # group the requests by type and get box plot stats for each type
         data = dtc_df \

--- a/server/test/test_db_service.py
+++ b/server/test/test_db_service.py
@@ -12,9 +12,10 @@ def test_serviceExists():
 def test_emptyQuery():
     # Arrange
     queryItems = []
+    filters = None
     data_worker = DataService()
     # Act
-    result = data_worker.query(queryItems)
+    result = data_worker.query(queryItems, filters)
     # Assert
     assert result['Error'] is not None
 
@@ -22,8 +23,9 @@ def test_emptyQuery():
 def test_nullQuery():
     # Arrange
     queryItems = None
+    filters = None
     data_worker = DataService()
     # Act
-    result = data_worker.query(queryItems)
+    result = data_worker.query(queryItems, filters)
     # Assert
     assert result['Error'] is not None


### PR DESCRIPTION
This PR does two things: (1) it changes the DataService to read from the database using pandas instead of the ORM, and (2) adds two materialized views to the database.

#### Reading with pandas instead of the ORM

Using pandas instead of the ORM to read from the DB makes the code simpler without hurting performance. If we continue to use the ORM, we'll have to define new models for every different table or view that we're reading from. Plus, with the ORM, reading requires two steps: first the DataService uses the ORM to generate a list of dictionaries, and second, the services that use the DataService put that data into a pandas dataframe. It's cleaner to just read the data into a dataframe (using `pd.read_sql`), since that's where it ends up anyway.

As for performance, I tested pandas reads vs. ORM reads pretty extensively. The read times were almost identical, with maybe a slight advantage to pandas reads. The code for those tests, and some handy charts, is [here](https://gist.github.com/jmensch1/c26e59127dc29267dd522417031e4392).

#### Materialized views

The PR creates two materialized views at the end of the ingest script. There's a view called 'map', which supports the `/pin-clusters` and `/heatmap` endpoints, and another one called 'vis', which supports all of the visualization and comparison endpoints. Both views have six columns, and both have indexes on all of the columns that we use for filtering.

As discussed on slack, reading from materialized views is way faster than reading from the full ingest staging table. (Code for those tests is [here](https://gist.github.com/jmensch1/6c5ab1a4ab5d8ea191487c925a5b80dc)). On my local, reading a one-year period with all request types and all NCs takes about 14 seconds when I used the full table, but only around 4 seconds to read from the 'map' view.  (4 seconds is still too slow IMO, and I'm gonna continue working on getting the time down.)

As for the 10M row limit on heroku -- I created a materialized view in the production database for testing, and it didn't have any effect on the row count in the heroku console. So it looks like materialized views don't count towards that limit.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
