### PR TITLE
metadata table with last_pulled populated during ingest

### DIFF
--- a/server/src/services/dataService.py
+++ b/server/src/services/dataService.py
@@ -1,4 +1,3 @@
-import datetime
 import pandas as pd
 from .databaseOrm import Ingest
 from utils.database import db
@@ -8,8 +7,8 @@ class DataService(object):
     default_table = Ingest.__tablename__
 
     async def lastPulled(self):
-        # Will represent last time the ingest pipeline ran
-        return datetime.datetime.utcnow()
+        rows = db.exec_sql('SELECT last_pulled FROM metadata')
+        return rows.first()[0]
 
     def standardFilters(self,
                         startDate=None,

--- a/server/src/services/sqlIngest.py
+++ b/server/src/services/sqlIngest.py
@@ -28,7 +28,11 @@ class DataHandler:
     def resetDatabase(self):
         log('\nResetting database.')
         db.exec_sql(f"""
-            DROP TABLE IF EXISTS {Ingest.__tablename__} CASCADE
+            DROP TABLE IF EXISTS {Ingest.__tablename__} CASCADE;
+
+            DROP TABLE IF EXISTS metadata;
+            CREATE TABLE metadata AS
+            SELECT * FROM (VALUES (NOW())) as vals(last_pulled);
         """)
         Base.metadata.create_all(db.engine)
 


### PR DESCRIPTION
Fixes #594

Tiny PR, adds a 'metadata' table during ingest with a single row and a 'last_pulled' column containing the time of the ingest. Dataservice adds this time to the `/apistatus` response.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
