### PR TITLE
picklecache

### DIFF
--- a/server/src/utils/redis.py
+++ b/server/src/utils/redis.py
@@ -1,3 +1,4 @@
+import os
 import redis
 import pickle
 from datetime import timedelta
@@ -35,4 +36,34 @@ class RedisCache(object):
             print(e)
 
 
-cache = RedisCache()
+class PickleCache(object):
+    CACHE_DIR = os.path.join(os.getcwd(), 'static/cache')
+
+    def __init__(self):
+        print('PICKLECACHE ENABLED')
+        os.makedirs(self.CACHE_DIR, exist_ok=True)
+
+    def config(self, config=None):
+        pass
+
+    def get(self, key):
+        try:
+            path = os.path.join(self.CACHE_DIR, key)
+            with open(path, 'rb') as f:
+                return pickle.load(f)
+        except Exception:
+            return None
+
+    def set(self, key, value):
+        try:
+            path = os.path.join(self.CACHE_DIR, key)
+            with open(path, 'wb') as f:
+                pickle.dump(value, f, protocol=pickle.HIGHEST_PROTOCOL)
+        except Exception as e:
+            print(e)
+
+
+if int(os.environ.get('PICKLECACHE')) == 1:
+    cache = PickleCache()
+else:
+    cache = RedisCache()

--- a/server/src/utils/redis.py
+++ b/server/src/utils/redis.py
@@ -63,7 +63,7 @@ class PickleCache(object):
             print(e)
 
 
-if int(os.environ.get('PICKLECACHE')) == 1:
+if int(os.environ.get('PICKLECACHE', 0)) == 1:
     cache = PickleCache()
 else:
     cache = RedisCache()


### PR DESCRIPTION
This is a drop-in replacement for Redis that caches stuff in the filesystem using python's `pickle` module.  The filenames are the same as the keys that we're already using for Redis. So it's essentially a file-based key-value store. 

On my local, the picklecache is about the same speed as Redis. And it won't be subject to the 25M limit that we have on heroku-redis. So I want to see how it performs on production. 

The code here doesn't do anything unless an environment variable called PICKLECACHE is set to 1, in which case it replaces Redis with the picklecache. When this is live I'll toggle the environment variable on heroku and see if there's any improvement. 


  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
