### PR TITLE
added GITHUB_SHA to environment

### DIFF
--- a/Orchestration/docker-compose-example.yml
+++ b/Orchestration/docker-compose-example.yml
@@ -14,6 +14,7 @@ services:
       SOCRATA_TOKEN: REDACTED
       GITHUB_TOKEN: REDACTED
       GITHUB_PROJECT_URL: REDACTED
+      GITHUB_SHA: DEVELOPMENT
     ports:
       - 5000:5000
     volumes:

--- a/server/src/settings.example.cfg
+++ b/server/src/settings.example.cfg
@@ -45,4 +45,4 @@ QUERY_SIZE = 50000
 TOKEN = __$GITHUB_TOKEN__
 ISSUES_URL = https://api.github.com/repos/hackforla/311-data/issues
 PROJECT_URL = __$GITHUB_PROJECT_URL__
-SHA = DEVELOPMENT
+SHA = __$GITHUB_SHA__


### PR DESCRIPTION
When refactoring the config I forgot to add GITHUB_SHA to the environment.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
