### PR TITLE
Pickle base fix

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -4,7 +4,7 @@ from sanic_cors import CORS
 from sanic_gzip import Compress
 from threading import Timer
 from datetime import datetime
-from multiprocessing import cpu_count
+from multiprocessing import cpu_count, Process
 
 from services.pinClusterService import PinClusterService
 from services.heatmapService import HeatmapService
@@ -15,6 +15,7 @@ from services.feedbackService import FeedbackService
 from services.dataService import DataService
 
 from utils.sanic import add_performance_header
+from utils.picklebase import pb
 from config import config
 
 app = Sanic(__name__)
@@ -165,6 +166,9 @@ if __name__ == '__main__':
 
     if workers == -1:
         workers = max(cpu_count() // 2, 1)
+
+    if pb.enabled:
+        Process(target=pb.populate).start()
 
     app.run(
         port=port,

--- a/server/src/services/dataService.py
+++ b/server/src/services/dataService.py
@@ -19,7 +19,7 @@ class DataService(object):
         '''
         Generates filters for dates, request types, and ncs.
         '''
-        if pb.enabled:
+        if pb.available():
             return {
                 'startDate': startDate,
                 'endDate': endDate,
@@ -44,7 +44,7 @@ class DataService(object):
         '''
         Generates filters for the comparison endpoints.
         '''
-        if pb.enabled:
+        if pb.available():
             return {
                 'startDate': startDate,
                 'endDate': endDate,
@@ -94,7 +94,7 @@ class DataService(object):
         if not fields or not filters:
             return {'Error': 'fields and filters are required'}
 
-        if pb.enabled:
+        if pb.available():
             return pb.query(table, fields, filters)
 
         fields = (', ').join(fields)

--- a/server/src/utils/picklebase/__init__.py
+++ b/server/src/utils/picklebase/__init__.py
@@ -1,27 +1,35 @@
 import os
 from .query import query as query_pb
 from .populate import populate as populate_pb
+from .data_access import clear_data, set_ready, check_ready
 
 
 class PickleBase(object):
     def __init__(self):
-        self.enabled = False
+        self.enabled = int(os.environ.get('PICKLEBASE', 0)) == 1
+        self.ready = False
+
+    def available(self):
+        if not self.enabled:
+            return False
+        if self.ready:
+            return True
+        self.ready = check_ready()
+        return self.ready
 
     def populate(self):
-        populate_pb()
+        try:
+            clear_data()
+            populate_pb()
+            set_ready()
+            print('PICKLEBASE IS READY')
+        except Exception as e:
+            self.enabled = False
+            print('FAILED TO POPULATE PICKLEBASE')
+            print(e)
 
     def query(self, table, fields, filters):
         return query_pb(table, fields, filters)
 
 
 pb = PickleBase()
-
-
-if int(os.environ.get('PICKLEBASE', 0)) == 1:
-    print('PICKLEBASE ENABLED')
-    try:
-        pb.populate()
-        pb.enabled = True
-    except Exception as e:
-        print('FAILED TO POPULATE PICKLEBASE')
-        print(e)

--- a/server/src/utils/picklebase/data_access.py
+++ b/server/src/utils/picklebase/data_access.py
@@ -6,6 +6,7 @@ import json
 
 TMP_DIR = os.environ.get('TMP_DIR', os.getcwd())
 DATA_DIR = os.path.join(TMP_DIR, 'static/picklebase')
+READY_FILE = os.path.join(DATA_DIR, 'ready')
 
 
 def clear_data():
@@ -58,3 +59,12 @@ def load_meta(table):
     path = meta_path(table)
     with open(path, 'r') as f:
         return json.load(f)
+
+
+def set_ready():
+    with open(READY_FILE, 'w') as f:
+        pass
+
+
+def check_ready():
+    return os.path.isfile(READY_FILE)

--- a/server/src/utils/picklebase/data_access.py
+++ b/server/src/utils/picklebase/data_access.py
@@ -62,7 +62,7 @@ def load_meta(table):
 
 
 def set_ready():
-    with open(READY_FILE, 'w') as f:
+    with open(READY_FILE, 'w'):
         pass
 
 

--- a/server/src/utils/picklebase/populate.py
+++ b/server/src/utils/picklebase/populate.py
@@ -1,6 +1,5 @@
 import os
 from utils.database import db
-from .data_access import clear_data
 from .create_table import create_table
 
 
@@ -52,6 +51,5 @@ def create_vis_table():
 
 
 def populate():
-    clear_data()
     create_map_table()
     create_vis_table()

--- a/server/src/utils/picklebase/query.py
+++ b/server/src/utils/picklebase/query.py
@@ -12,6 +12,8 @@ def get_batch_nums(table, startDate, endDate):
 
 
 def query(table, fields, filters):
+    print('QUERYING PICKLEBASE')
+
     startDate = pd.to_datetime(filters['startDate'])
     endDate = pd.to_datetime(filters['endDate'])
     requestTypes = filters['requestTypes']


### PR DESCRIPTION
So in the last round I was trying to populate the picklebase before starting the server. It took longer than 60 seconds, so the server failed with an error:

```
Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch
```

In this PR the server is started immediately, and the picklebase is populated in a separate process. A file called 'ready' is created when process finishes, which informs the Sanic workers that they can query the picklebase instead of the database.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
