### PR TITLE
updating DB and picklebase on server start

### DIFF
--- a/.github/workflows/Publish_Backend_Package.yml
+++ b/.github/workflows/Publish_Backend_Package.yml
@@ -27,7 +27,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         registry: docker.pkg.github.com
         dockerfile: server/api/Dockerfile
-        context: server
+        context: server/api
         tags: "latest, ${{github.sha}}"
     - name: Login to heroku
       env:
@@ -37,7 +37,7 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       run: |
-        docker tag docker.pkg.github.com/hackforla/311-data/api:${{github.sha}} registry.heroku.com/hackforla-311/web
+        docker tag docker.pkg.github.com/hackforla/311-data/backend:${{github.sha}} registry.heroku.com/hackforla-311/web
         docker push registry.heroku.com/hackforla-311/web
     - name: Release
       env:

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,6 +8,7 @@ ACCESS_LOG=1
 AUTO_RELOAD=1
 WORKERS=1
 TMP_DIR=./__tmp__
+UPDATE_ON_START=0
 
 # Database
 DATABASE_URL=postgresql://311_user:311_pass@db:5432/311_db

--- a/server/api/bin/api_check.py
+++ b/server/api/bin/api_check.py
@@ -72,6 +72,7 @@ def show_db_contents():
 if __name__ == '__main__':
     from utils.log import log_heading
     import time
+    from settings import Server
 
     time.sleep(1)
 
@@ -82,11 +83,12 @@ if __name__ == '__main__':
     # log_heading('database contents')
     # show_db_contents()
 
-    import pb
-    if not pb.enabled:
-        pb.clear_data()
-    elif not pb.available():
-        pb.populate()
+    if not Server.UPDATE_ON_START:
+        import pb
+        if not pb.enabled:
+            pb.clear_data()
+        elif not pb.available():
+            pb.populate()
 
     from utils.settings import log_settings
     log_heading('settings')

--- a/server/api/bin/api_start.py
+++ b/server/api/bin/api_start.py
@@ -3,6 +3,29 @@ from os.path import join, dirname
 sys.path.append(join(dirname(__file__), '../src'))
 
 
+def update():
+    from datetime import datetime
+    import time
+    import db
+    import pb
+
+    time.sleep(5)
+
+    last_updated = db.info.last_updated()
+    time_since_update = datetime.utcnow() - last_updated
+    if time_since_update.days >= 1:
+        db.requests.update()
+
+    if pb.enabled:
+        pb.populate()
+
+
 if __name__ == '__main__':
     import app
+    from multiprocessing import Process
+    from settings import Server
+
+    if Server.UPDATE_ON_START:
+        Process(target=update).start()
+
     app.start()

--- a/server/api/src/settings.py
+++ b/server/api/src/settings.py
@@ -17,6 +17,7 @@ class Server:
     AUTO_RELOAD = env('AUTO_RELOAD', to.BOOL)
     WORKERS = env('WORKERS', to.INT)
     TMP_DIR = env('TMP_DIR', to.ABS_PATH)
+    UPDATE_ON_START = env('UPDATE_ON_START', to.BOOL)
 
 
 class Database:


### PR DESCRIPTION
This does a background update of the database and the picklebase when the server starts, provided the UPDATE_ON_START env var is set to 1. That var is really just a proxy for "are we running on heroku?" 

The reason we need to update when the server starts, instead of running a cron job, is that heroku wipes out the filesystem, and with it the picklebase, whenever the server restarts. The server automatically restarts every 24 hours, so that's a convenient time to update the database as well.

Once this is merged to `dev`, we can do a push to `master`.

UPDATE:
I tweaked the backend workflow a bit to (hopefully) make the registry publishing work correctly.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
