### PR TITLE
increased size of text in mapbox tiles

### DIFF
--- a/src/components/PinMap/PinMap.jsx
+++ b/src/components/PinMap/PinMap.jsx
@@ -284,6 +284,8 @@ class PinMap extends Component {
               <TileLayer
                 url={satelliteLayerUrl}
                 attribution="MapBox"
+                tileSize={512}
+                zoomOffset={-1}
               />
             </BaseLayer>
             {

--- a/src/components/PinMap/PinMap.jsx
+++ b/src/components/PinMap/PinMap.jsx
@@ -276,6 +276,8 @@ class PinMap extends Component {
               <TileLayer
                 url={streetsLayerUrl}
                 attribution="MapBox"
+                tileSize={512}
+                zoomOffset={-1}
               />
             </BaseLayer>
             <BaseLayer name="Satellite">


### PR DESCRIPTION
The text was really small in the mapbox tiles on the `dev` site. I used this solution from stackoverflow: https://stackoverflow.com/questions/37040494/street-labels-in-mapbox-tile-layer-too-small

Now it looks right (this is from my local):

<img width="509" alt="Screen Shot 2020-07-08 at 11 24 01 AM" src="https://user-images.githubusercontent.com/9143823/86956363-ce69d780-c10d-11ea-9696-608224397f8c.png">


  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
