### PR TITLE
Url fix for og tags, primary/alt request type colors

### DIFF
--- a/.github/workflows/Continuous_Deployment_Frontend_Dev.yml
+++ b/.github/workflows/Continuous_Deployment_Frontend_Dev.yml
@@ -6,6 +6,7 @@ on:
       - dev
     paths:
       - 'src/**'
+      - 'public/**'
 
 jobs:
   build:

--- a/.github/workflows/Continuous_Deployment_Frontend_Prod.yml
+++ b/.github/workflows/Continuous_Deployment_Frontend_Prod.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'src/**'
+      - 'public/**'
 
 jobs:
   build:

--- a/.github/workflows/Continuous_Integration_Frontend.yml
+++ b/.github/workflows/Continuous_Integration_Frontend.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'src/**'
+      - 'public/**'
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "start": "npm run check-env && npm run dev",
     "dev": "webpack-dev-server --config webpack.dev.js",
-    "build": "NODE_ENV=production webpack --config webpack.prod.js",
+    "build": "webpack --config webpack.prod.js",
     "lint": "eslint 'src/**/*.js*'",
     "test": "jest --passWithNoTests",
     "predeploy": "npm run build",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "start": "npm run check-env && npm run dev",
     "dev": "webpack-dev-server --config webpack.dev.js",
-    "build": "webpack --config webpack.prod.js",
+    "build": "NODE_ENV=production webpack --config webpack.prod.js",
     "lint": "eslint 'src/**/*.js*'",
     "test": "jest --passWithNoTests",
     "predeploy": "npm run build",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,11 +8,11 @@ import { getMetadataRequest } from '@reducers/metadata';
 import RouteChange from '@components/main/util/RouteChange';
 import actions from '@components/main/util/routeChangeActions';
 import CookieNotice from '@components/main/body/CookieNotice';
+import Header from '@components/main/header/Header';
+import Footer from '@components/main/footer/Footer';
+import StaticFooter from '@components/main/footer/StaticFooter';
+import { SnapshotRenderer } from '@components/export/SnapshotService';
 import Routes from './Routes';
-import Header from './components/main/header/Header';
-import Footer from './components/main/footer/Footer';
-import StaticFooter from './components/main/footer/StaticFooter';
-import { SnapshotRenderer } from './components/export/SnapshotService';
 
 const App = ({
   getMetadata,

--- a/src/components/common/CONSTANTS.js
+++ b/src/components/common/CONSTANTS.js
@@ -1,60 +1,129 @@
 export default {};
 
+// 'primary' or 'alt' to change request type colors
+const COLOR_SELECTION = 'primary';
+
 export const REQUEST_TYPES = {
   'Dead Animal Removal': {
     displayName: 'Dead Animal',
     abbrev: 'DAN',
-    color: '#768393',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#4FEFEF',
+      alt: '#768393',
+    },
   },
   'Homeless Encampment': {
     displayName: 'Homeless Encampment',
     abbrev: 'HLE',
-    color: '#C16B1A',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#ECB800',
+      alt: '#C16B1A',
+    },
   },
   'Single Streetlight Issue': {
     displayName: 'Single Streetlight',
     abbrev: 'SSL',
-    color: '#2B87C5',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#AD7B56',
+      alt: '#2B87C5',
+    },
   },
   'Multiple Streetlight Issue': {
     displayName: 'Multiple Streetlight',
     abbrev: 'MSL',
-    color: '#1B9365',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#F7ADAD',
+      alt: '#1B9365',
+    },
   },
   Feedback: {
     displayName: 'Feedback',
     abbrev: 'FBK',
-    color: '#0E251D',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#FFE6B7',
+      alt: '#0E251D',
+    },
   },
   'Bulky Items': {
     displayName: 'Bulky Items',
     abbrev: 'BLK',
-    color: '#C056C8',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#FF0000',
+      alt: '#C056C8',
+    },
   },
   'Electronic Waste': {
     displayName: 'E-Waste',
     abbrev: 'EWT',
-    color: '#EA435C',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#DDEC9F',
+      alt: '#EA435C',
+    },
   },
   'Metal/Household Appliances': {
     displayName: 'Metal/Household Appliances',
     abbrev: 'MHA',
-    color: '#4F7CEE',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#B8D0FF',
+      alt: '#4F7CEE',
+    },
   },
   'Graffiti Removal': {
     displayName: 'Graffiti',
     abbrev: 'GFT',
-    color: '#4F5564',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#2368D0',
+      alt: '#4F5564',
+    },
   },
   'Illegal Dumping Pickup': {
     displayName: 'Illegal Dumping',
     abbrev: 'ILD',
-    color: '#8F70D7',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#6A8011',
+      alt: '#8F70D7',
+    },
   },
   Other: {
     displayName: 'Other',
     abbrev: 'OTH',
-    color: '#842D8B',
+    get color() {
+      return this.colors[COLOR_SELECTION];
+    },
+    colors: {
+      primary: '#6D7C93',
+      alt: '#842D8B',
+    },
   },
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const SocialTags = require('social-tags-webpack-plugin');
 
-const envUrl = process.env.NODE_ENV === 'production' ? 'https://www.311-data.org/' : 'http://dev.311-data.org/';
 const description = 'Hack for LA’s 311-Data Team has partnered with the Los Angeles Department of Neighborhood Empowerment and LA Neighborhood Councils to create 311 data dashboards to provide all City of LA neighborhoods with actionable information at the local level.';
 
 module.exports = {
@@ -91,10 +90,10 @@ module.exports = {
       filename: '[name].css',
     }),
     new SocialTags({
-      appUrl: envUrl,
+      appUrl: 'https://www.311-data.org/',
       facebook: {
         'og:type': 'website',
-        'og:url': envUrl,
+        'og:url': 'https://www.311-data.org/',
         'og:title': '311-Data Neighborhood Engagement Tool',
         'og:image': './public/social-media-card-image.png',
         'og:description': description,
@@ -103,7 +102,7 @@ module.exports = {
       },
       twitter: {
         'twitter:card': 'summary_large_image',
-        'twitter:url': envUrl,
+        'twitter:url': 'https://www.311-data.org/',
         'twitter:title': '311-Data Neighborhood Engagement Tool',
         'twitter:image': './public/social-media-card-image.png',
         'twitter:description': description,


### PR DESCRIPTION
This uses the correct prod url for social media cards.
Added primary and alt colors to REQUEST_TYPES constant to allow switching between color schemes.

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
