### PR TITLE
IE11 support - fix dfa version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "classnames": "^2.2.6",
     "core-js": "^3.6.5",
     "dataframe-js": "^1.4.3",
-    "dfa": "^1.1.0",
+    "dfa": "1.1.0",
     "dotenv": "^8.2.0",
     "dotenv-webpack": "^1.7.0",
     "gh-pages": "^2.1.1",


### PR DESCRIPTION
Removed caret from `dfa` version in package.json. This was causing the package-lock.json to specify dfa version 1.2.0 instead of 1.1.0 which ended up breaking the site in IE11.

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
