### PR TITLE
Styles: request type colors, map markers/tooltips stacking order

### DIFF
--- a/src/components/common/CONSTANTS.js
+++ b/src/components/common/CONSTANTS.js
@@ -1,7 +1,7 @@
 export default {};
 
 // 'primary' or 'alt' to change request type colors
-const COLOR_SELECTION = 'alt';
+const COLOR_SELECTION = 'primary';
 
 export const REQUEST_TYPES = {
   'Dead Animal Removal': {

--- a/src/styles/map/_map.scss
+++ b/src/styles/map/_map.scss
@@ -41,7 +41,30 @@
     }
   }
 
+  .leaflet-tooltip-pane {
+    z-index: auto;
+
+    .overlay-nc-name {
+      z-index: 600;
+      opacity: 0.75 !important;
+      display: inline-block;
+      font-weight: bold;
+      font-size: 18px;
+      color: $brand-bg-color;
+      font-family: $brand-text-family;
+      background: none;
+      border: none;
+      box-shadow: none;
+      text-shadow:
+        -1px -1px 0 #000,
+        1px -1px 0 #000,
+        -1px 1px 0 #000,
+        1px 1px 0 #000;
+    }
+  }
+
   .leaflet-tooltip {
+    z-index: 700;
     position: absolute;
     border: 2px solid $brand-text-color;
     border-radius: 0;
@@ -59,20 +82,13 @@
     content: "";
   }
 
-  .overlay-nc-name {
-    display: inline-block;
-    font-weight: bold;
-    font-size: 18px;
-    color: $brand-bg-color;
-    font-family: $brand-text-family;
-    background: none;
-    border: none;
-    box-shadow: none;
-    text-shadow:
-      -1px -1px 0 #000,
-      1px -1px 0 #000,
-      -1px 1px 0 #000,
-      1px 1px 0 #000;
+  .leaflet-marker-pane {
+    z-index: auto;
+
+    .leaflet-marker-icon,
+    .marker-cluster {
+      z-index: 650 !important;
+    }
   }
 
   .export-legend-wrapper {


### PR DESCRIPTION
- Changed to primary request type colors for prod update.
- Fixed stacking order for map markers/clusters and tooltips.

**Tooltip above markers unless marker/cluster is hovered:**

![Screen Shot 2020-08-05 at 11 10 08 AM](https://user-images.githubusercontent.com/40484278/89448342-55f63680-d70c-11ea-96d1-d2544ab9742a.png)

**Markers/clusters above NC name at zoom:**

![Screen Shot 2020-08-05 at 11 10 40 AM](https://user-images.githubusercontent.com/40484278/89448352-58f12700-d70c-11ea-9780-eab2244ac07a.png)


  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
