### PR TITLE
Cypress e2e workflow update

### DIFF
--- a/e2e/cypress/integration/e2e_tests.spec.js
+++ b/e2e/cypress/integration/e2e_tests.spec.js
@@ -21,7 +21,7 @@ describe('311 Data', () => {
             cy.get('.dropdown-trigger > .button').click()
             cy.get('[value="LAST_WEEK"]').click()
             cy.get(':nth-child(2) > .select-group-content > .select-item > .select-item-box').click()
-            cy.get('#type-selector-container > div.columns.is-0 > div:nth-child(1) > div:nth-child(2) > span > input').click({force: true})
+            cy.get('#type-selector-container > div.columns.is-gapless > div:nth-child(1) > div:nth-child(2) > span > input').click({force: true})
             cy.get('#btn-sidebar-submit-button').click()
 
             cy.wait('@getFilterList').should((xhr) => {
@@ -58,7 +58,7 @@ describe('311 Data', () => {
             cy.get('.dropdown-trigger > .button').click()
             cy.get('[value="LAST_WEEK"]').click()
             cy.get(':nth-child(2) > .select-group-content > .select-item > .select-item-box').click()
-            cy.get('#type-selector-container > div.columns.is-0 > div:nth-child(1) > div:nth-child(2) > span > input').click({force: true})
+            cy.get('#type-selector-container > div.columns.is-gapless > div:nth-child(1) > div:nth-child(2) > span > input').click({force: true})
             cy.get('#btn-sidebar-submit-button').click()
 
             cy.wait('@getFilterList').should((xhr) => {


### PR DESCRIPTION
Related to #799 

Updated type-selector class name in e2e_tests spec to fix failing tests. Class name was changed in #800 .

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
