### PR TITLE
Accessibility Panel Tweak

### DIFF
--- a/client/components/main/header/AccessibilityPane.jsx
+++ b/client/components/main/header/AccessibilityPane.jsx
@@ -15,7 +15,7 @@ const AccessibilityPane = () => {
   };
 
   const handleKeyDown = e => {
-    if (e.key !== 'Tab' && e.key !== 'Shift' && e.key !== 'Alt') {
+    if (e.key === ' ' || e.key === 'Enter') {
       handleClick(e);
     }
   };

--- a/client/components/main/header/AccessibilityPane.jsx
+++ b/client/components/main/header/AccessibilityPane.jsx
@@ -15,7 +15,7 @@ const AccessibilityPane = () => {
   };
 
   const handleKeyDown = e => {
-    if (e.key !== 'Tab' && e.key !== 'Shift') {
+    if (e.key !== 'Tab' && e.key !== 'Shift' && e.key !== 'Alt') {
       handleClick(e);
     }
   };

--- a/client/components/main/header/AccessibilityPane.jsx
+++ b/client/components/main/header/AccessibilityPane.jsx
@@ -14,6 +14,12 @@ const AccessibilityPane = () => {
     updateIsOpen(!isOpen);
   };
 
+  const handleKeyDown = e => {
+    if (e.key !== 'Tab' && e.key !== 'Shift') {
+      handleClick(e);
+    }
+  };
+
   const renderInstructions = () => ACCESSIBILITY_INSTRUCTIONS.map((element, index) => {
     if (index % 2 !== 0) {
       return (
@@ -40,7 +46,7 @@ const AccessibilityPane = () => {
     <div // eslint-disable-line
       className={dropdownClassName}
       tabIndex={0}
-      onKeyDown={handleClick}
+      onKeyDown={handleKeyDown}
       aria-expanded={isOpen}
       role="button"
     >

--- a/client/components/main/header/Header.jsx
+++ b/client/components/main/header/Header.jsx
@@ -23,6 +23,12 @@ const Header = () => {
     setActiveBurger(!activeBurger);
   };
 
+  const handleKeyDown = e => {
+    if (e.key !== 'Tab' && e.key !== 'Shift') {
+      handleClick(e);
+    }
+  };
+
   return (
     <nav
       className="navbar"
@@ -49,7 +55,7 @@ const Header = () => {
           aria-label="menu"
           aria-expanded={activeBurger}
           onClick={handleClick}
-          onKeyDown={handleClick}
+          onKeyDown={handleKeyDown}
         >
           <span aria-hidden="true" />
           <span aria-hidden="true" />

--- a/client/components/main/header/Header.jsx
+++ b/client/components/main/header/Header.jsx
@@ -24,7 +24,7 @@ const Header = () => {
   };
 
   const handleKeyDown = e => {
-    if (e.key !== 'Tab' && e.key !== 'Shift') {
+    if (e.key !== 'Tab' && e.key !== 'Shift' && e.key !== 'Alt') {
       handleClick(e);
     }
   };

--- a/client/components/main/header/Header.jsx
+++ b/client/components/main/header/Header.jsx
@@ -24,7 +24,7 @@ const Header = () => {
   };
 
   const handleKeyDown = e => {
-    if (e.key !== 'Tab' && e.key !== 'Shift' && e.key !== 'Alt') {
+    if (e.key === ' ' || e.key === 'Enter') {
       handleClick(e);
     }
   };

--- a/client/styles/main/_header.scss
+++ b/client/styles/main/_header.scss
@@ -106,7 +106,7 @@
       right: auto;
       left: -350px;
       top: 45px;
-      height: calc(100vh - #{$header-height + $hamburger-height});
+      height: calc(100vh - #{$header-height + $hamburger-height + 40px});
     }
   }
 


### PR DESCRIPTION
Tweaked Accessibility Panel styling so it scrolls to the bottom of the panel in a minimized screen. Also 'Shift', 'Tab', and 'Alt' key presses do not toggle the Hamburger Menu or Accessibility Dropdown

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
