### PR TITLE
disabling cypress for now

### DIFF
--- a/misc/workflows/End_To_End_Tests.yml
+++ b/misc/workflows/End_To_End_Tests.yml
@@ -1,3 +1,7 @@
+# DISABLED UNTIL: (1) we get more test coverage, and
+# (2) the tests run against the code that's being pushed
+# instead of the code already on dev
+
 name: End-to-end tests
 on: [push]
 jobs:


### PR DESCRIPTION
This just disables the github action that runs the cypress tests. The tests are far from complete and are sometimes causing problems with PRs. Plus they run against the code that's already on the dev server rather than the code that's actually being pushed, which doesn't make much sense. 

In order to use Cypress properly in CI/CD we'd need to have a github action that fires up both the api and the frontend, and then runs the cypress tests against that app instead of the one on dev.

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
