### PR TITLE
Enable filtering on /requests endpoint

### DIFF
--- a/server/api/code/lacity_data_api/routers/reports.py
+++ b/server/api/code/lacity_data_api/routers/reports.py
@@ -30,6 +30,7 @@ field_dict = {
 filter_regex = "^(\w+)([>=<]+)([\w-]+)$"  # noqa
 
 
+# TODO: add created_dow option
 @router.get("")
 async def run_report(
     field: Optional[List[str]] = Query(

--- a/server/api/tests/integration/test_api_requests.py
+++ b/server/api/tests/integration/test_api_requests.py
@@ -3,7 +3,42 @@ def test_service_requests(client):
     url = "/requests"
     response = client.get(url)
     assert response.status_code == 200
-    assert len(response.json()) == 100
+    assert len(response.json()) == 0
+
+
+def test_service_requests_start(client):
+    url = "/requests?start_date=2020-01-01"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.json()) == 9877
+
+
+def test_service_requests_end(client):
+    url = "/requests?start_date=2020-01-01&end_date=2020-01-02"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.json()) == 7574
+
+
+def test_service_requests_type(client):
+    url = "/requests?start_date=2020-01-01&end_date=2020-01-02&type_id=2"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.json()) == 297
+
+
+def test_service_requests_council(client):
+    url = "/requests?start_date=2020-01-01&end_date=2020-01-02&council_id=4"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.json()) == 38
+
+
+def test_service_requests_all(client):
+    url = "/requests?start_date=2020-01-01&end_date=2020-01-02&type_id=2&council_id=4"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.json()) == 3
 
 
 def test_service_request(client):


### PR DESCRIPTION
- Should default to last week's data if no limit provided
- Can filter on date, council, and type

Fixes #942
