### PR TITLE
Add CORS checks

### DIFF
--- a/server/api/code/lacity_data_api/config.py
+++ b/server/api/code/lacity_data_api/config.py
@@ -18,6 +18,12 @@ SHOW_ENV = config("SHOW_ENV", cast=bool, default=False)
 TESTING = config("TESTING", cast=bool, default=False)
 STAGE = config("STAGE", default="Local")
 
+# string array of allows client URLs
+API_ALLOWED_ORIGINS = config(
+    "API_ALLOWED_ORIGINS",
+    default=["http://localhost:3000", "https://*.311-data.org"]
+)
+
 # getting database configuration
 DB_DRIVER = config("DB_DRIVER", default="postgresql")
 DB_HOST = config("DB_HOST", default="localhost")

--- a/server/api/code/lacity_data_api/main.py
+++ b/server/api/code/lacity_data_api/main.py
@@ -6,7 +6,7 @@ from fastapi.logger import logger as fastapi_logger
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 
-from .config import DEBUG
+from .config import DEBUG, API_ALLOWED_ORIGINS
 from .models import db
 from .routers import (
     index, councils, regions, request_types, service_requests, shim, status,
@@ -45,7 +45,7 @@ def get_app():
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=API_ALLOWED_ORIGINS,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION
Fixes #954

For the moment, I'm restricting this to http://localhost:3000 and https://*.311-data.org which will allow developers to use the dev environment with their local React environments without needing to change the build process.

When I do the production build I'll override with the production client URL.

It would probably be better to do it the other way (i.e. override dev to add localhost if needed) but I think this is less painful for now. Might switch it later.