### PR TITLE
Integrate Dash reports into the app

### DIFF
--- a/client/Routes.jsx
+++ b/client/Routes.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import {
-  Switch,
-  Route,
-  Redirect,
-} from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 import Desktop from '@components/main/Desktop';
+import Reports from '@components/main/Reports';
 
 export default function Routes() {
   return (
     <Switch>
       <Route path="/map" component={Desktop} />
+      <Route path="/reports" component={Reports} />
       <Route path="/">
         <Redirect to="map" />
       </Route>

--- a/client/components/Header.jsx
+++ b/client/components/Header.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
-// import { NavLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   AppBar,
   Button,
   Toolbar,
   Typography,
+  Menu,
+  MenuItem,
 } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
+  MuiMenuItemButton: {
+    color: 'white',
+  },
   appBar: {
     height: theme.header.height,
     backgroundColor: theme.palette.primary.main,
@@ -16,7 +21,10 @@ const useStyles = makeStyles(theme => ({
   button: {
     textTransform: 'none',
     fontFamily: 'Roboto',
-    marginLeft: theme.spacing(2),
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+    color: 'white',
+    textDecoration: 'none',
   },
   title: {
     ...theme.typography.h1,
@@ -30,6 +38,15 @@ const useStyles = makeStyles(theme => ({
 // TODO: links/routing, mobile
 const Header = () => {
   const classes = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleClick = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   return (
     <AppBar position="static" className={classes.appBar}>
@@ -37,7 +54,49 @@ const Header = () => {
         <Typography variant="h1" className={classes.title}>
           311DATA
         </Typography>
-        <Button className={classes.button}>Explore 311 Data</Button>
+        <Button
+          id="report-anchor"
+          onClick={handleClick}
+          className={classes.button}
+        >
+          Reports
+        </Button>
+        <Menu
+          id="report-menu"
+          anchorEl={anchorEl}
+          keepMounted
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+          getContentAnchorEl={null}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+        >
+          <Link to="/reports/dashboards/overview">
+            <MenuItem onClick={handleClose} button className={classes.button}>
+              Overview
+            </MenuItem>
+          </Link>
+          <Link to="/reports/dashboards/recent">
+            <MenuItem onClick={handleClose} button className={classes.button}>
+              Recent
+            </MenuItem>
+          </Link>
+          <Link to="/reports/dashboards/neighborhood">
+            <MenuItem onClick={handleClose} button className={classes.button}>
+              Neighborhood
+            </MenuItem>
+          </Link>
+          <Link to="/reports/dashboards/neighborhood_recent">
+            <MenuItem onClick={handleClose} button className={classes.button}>
+              Neighborhood Recent
+            </MenuItem>
+          </Link>
+        </Menu>
+        <Link to="/map">
+          <Button className={classes.button}>Explore 311 Data</Button>
+        </Link>
         <Button className={classes.button}>About 311 Data</Button>
         <Button className={classes.button}>Contact Us</Button>
         <Button className={classes.button}>Help Center</Button>

--- a/client/components/main/Reports.jsx
+++ b/client/components/main/Reports.jsx
@@ -1,9 +1,25 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
 import { Backdrop, CircularProgress } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    height: `calc(100vh - ${theme.header.height} - ${theme.footer.height})`,
+    width: '100vw',
+    backgroundColor: 'black',
+  },
+  backdrop: {
+    position: 'absolute',
+    top: theme.header.height,
+    bottom: theme.footer.height,
+    height: `calc(100vh - ${theme.header.height} - ${theme.footer.height})`,
+  },
+}));
 
 const Reports = () => {
   const [isLoading, setIsLoading] = React.useState(true);
+  const classes = useStyles();
 
   const url = process.env.REPORT_URL;
   let reportPath = '/dashboards/overview';
@@ -26,14 +42,14 @@ const Reports = () => {
 
   return (
     <div
-      style={{
-        width: '100%',
-        height: '100%',
-        minHeight: '100%',
-        backgroundColor: 'black',
-      }}
+      className={classes.root}
     >
-      <Backdrop style={{ zIndex: 100 }} open={isLoading} invisible={!isLoading}>
+      <Backdrop
+        className={classes.backdrop}
+        style={{ zIndex: 100 }}
+        open={isLoading}
+        invisible={!isLoading}
+      >
         <CircularProgress />
       </Backdrop>
       <iframe

--- a/client/components/main/Reports.jsx
+++ b/client/components/main/Reports.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { Backdrop, CircularProgress } from '@material-ui/core';
+
+const Reports = () => {
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  const url = process.env.REPORT_URL;
+  let reportPath = '/dashboards/overview';
+  const location = useLocation();
+  reportPath = location.pathname.slice(8);
+  const reportRef = React.useRef(reportPath);
+
+  /* eslint-disable consistent-return */
+  React.useEffect(() => {
+    if (reportPath !== reportRef.current) {
+      setIsLoading(true);
+    }
+
+    if (isLoading) {
+      const timer = setTimeout(() => setIsLoading(false), 2000);
+      return () => clearTimeout(timer);
+    }
+    reportRef.current = reportPath;
+  }, [reportPath, isLoading]);
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        minHeight: '100%',
+        backgroundColor: 'black',
+      }}
+    >
+      <Backdrop style={{ zIndex: 100 }} open={isLoading} invisible={!isLoading}>
+        <CircularProgress />
+      </Backdrop>
+      <iframe
+        title="reportFrame"
+        src={url + reportPath}
+        frameBorder="0"
+        allowFullScreen
+        style={{ width: '100%', height: '100%', minHeight: '55em' }}
+      />
+    </div>
+  );
+};
+
+export default Reports;


### PR DESCRIPTION
Fixes #837

- Added menu to Header with the reports (dashboard names and URLs are hand-coded for now)
- Expects the REPORT_URL env variable to be set to https://dash-reporting.tofn9kh9mlm7g.us-east-1.cs.amazonlightsail.com
- Added a new Reports page with a Loader and iframe for the reports

I'm a little uncertain what the approach is for styling. I got the menu looking OK, but not sure if it's the best approach. Felt like I was fighting Material UI a bit too.

There's also a footer bug with the reports. Hoping someone can help with that.

Also, it looks like the Map isn't properly unloading so it might crash as a result.