### PR TITLE
Removed expanded default prop for CouncilSelector dropdown

### DIFF
--- a/client/components/main/Desktop/CouncilSelector/index.js
+++ b/client/components/main/Desktop/CouncilSelector/index.js
@@ -55,7 +55,7 @@ const CouncilSelector = ({
   return (
     <>
       <div className={classes.label}>Council Districts</div>
-      <SelectorBox expanded>
+      <SelectorBox>
         <SelectorBox.Display>
           <SelectedCouncils
             items={selected}


### PR DESCRIPTION
Removed `expanded` prop from CouncilSelector SelectorBox so it doesn't renders closed.

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
