### PR TITLE
mapboxgl-popup-content width fix

### DIFF
--- a/client/components/Map/Map.jsx
+++ b/client/components/Map/Map.jsx
@@ -53,7 +53,7 @@ const styles = theme => ({
       display: 'none',
     },
     '& .mapboxgl-popup-content': {
-      minWidth: 250,
+      width: 'auto',
       backgroundColor: theme.palette.primary.main,
       borderRadius: 5,
       padding: 10,


### PR DESCRIPTION
Fixes width for request detail popup loader.

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
