### PR TITLE
RequestsLayer circle-color fix

### DIFF
--- a/client/components/Map/Map.jsx
+++ b/client/components/Map/Map.jsx
@@ -158,7 +158,8 @@ class Map extends React.Component {
       }
     }
 
-    if (this.props.requestTypes != prevProps.requestTypes || !this.map.getSource('requests')) {
+    // if (this.props.requestTypes != prevProps.requestTypes || !this.map.getSource('requests')) {
+    if (this.props.requestTypes != prevProps.requestTypes && this.map != null) {
       this.requestsLayer.init({
         map: this.map,
       });

--- a/client/components/Map/Map.jsx
+++ b/client/components/Map/Map.jsx
@@ -158,8 +158,7 @@ class Map extends React.Component {
       }
     }
 
-    // if (this.props.requestTypes != prevProps.requestTypes || !this.map.getSource('requests')) {
-    if (this.props.requestTypes != prevProps.requestTypes && this.map != null) {
+    if (this.props.requestTypes != prevProps.requestTypes) {
       this.requestsLayer.init({
         map: this.map,
       });

--- a/client/components/Map/RequestDetail.jsx
+++ b/client/components/Map/RequestDetail.jsx
@@ -202,7 +202,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(R
 RequestDetail.propTypes = {
   requestId: PropTypes.number,
   pinsInfo: PropTypes.shape({}),
-  requestTypes: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  requestTypes: PropTypes.arrayOf(PropTypes.shape({})),
   agencies: PropTypes.arrayOf(PropTypes.shape({})),
   getPinInfo: PropTypes.func.isRequired,
 };
@@ -210,5 +210,6 @@ RequestDetail.propTypes = {
 RequestDetail.defaultProps = {
   requestId: null,
   pinsInfo: {},
-  agencies: [],
+  agencies: null,
+  requestTypes: null,
 };

--- a/client/components/Map/layers/RequestsLayer.js
+++ b/client/components/Map/layers/RequestsLayer.js
@@ -29,11 +29,16 @@ function typeFilter(selectedTypes) {
 }
 
 class RequestsLayer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.ready = false;
+  }
+
   init = ({ map }) => {
     this.map = map;
-
     this.addSources();
     this.addLayers();
+    this.ready = true;
   }
 
   componentDidUpdate(prev) {
@@ -44,17 +49,17 @@ class RequestsLayer extends React.Component {
       colorScheme,
     } = this.props;
 
-    // if (activeLayer !== prev.activeLayer)
-      // this.setActiveLayer(activeLayer);
+    if (activeLayer !== prev.activeLayer)
+      this.setActiveLayer(activeLayer);
 
-    // if (selectedTypes !== prev.selectedTypes)
-      // this.setSelectedTypes(selectedTypes);
+    if (selectedTypes !== prev.selectedTypes)
+      this.setSelectedTypes(selectedTypes);
 
-    if (requests !== prev.requests)
+    if (requests !== prev.requests && this.ready)
       this.setRequests(requests);
 
-    // if (colorScheme !== prev.colorScheme)
-      // this.setColorScheme(colorScheme);
+    if (colorScheme !== prev.colorScheme)
+      this.setColorScheme(colorScheme);
   }
 
   addSources = () => {

--- a/client/components/Map/layers/RequestsLayer.js
+++ b/client/components/Map/layers/RequestsLayer.js
@@ -44,17 +44,17 @@ class RequestsLayer extends React.Component {
       colorScheme,
     } = this.props;
 
-    if (activeLayer !== prev.activeLayer)
-      this.setActiveLayer(activeLayer);
+    // if (activeLayer !== prev.activeLayer)
+      // this.setActiveLayer(activeLayer);
 
-    if (selectedTypes !== prev.selectedTypes)
-      this.setSelectedTypes(selectedTypes);
+    // if (selectedTypes !== prev.selectedTypes)
+      // this.setSelectedTypes(selectedTypes);
 
     if (requests !== prev.requests)
       this.setRequests(requests);
 
-    if (colorScheme !== prev.colorScheme)
-      this.setColorScheme(colorScheme);
+    // if (colorScheme !== prev.colorScheme)
+      // this.setColorScheme(colorScheme);
   }
 
   addSources = () => {

--- a/client/components/main/Desktop/RequestTypeSelector/index.js
+++ b/client/components/main/Desktop/RequestTypeSelector/index.js
@@ -90,10 +90,10 @@ export default connect(
 )(RequestTypeSelector);
 
 RequestTypeSelector.propTypes = {
-  requestTypes: PropTypes.arrayOf(PropTypes.shape({
-    typeId: PropTypes.number,
-    typeName: PropTypes.string,
-    color: PropTypes.string,
-  })).isRequired,
+  requestTypes: PropTypes.arrayOf(PropTypes.shape({})),
   updateTypesFilter: PropTypes.func.isRequired,
+};
+
+RequestTypeSelector.defaultProps = {
+  requestTypes: null,
 };

--- a/client/redux/reducers/metadata.js
+++ b/client/redux/reducers/metadata.js
@@ -55,7 +55,7 @@ const initialState = {
   version: null,
   lastPulledUTC: null,
   lastPulledLocal: null,
-  requestTypes: [],
+  requestTypes: null,
   councils: null,
   regions: null,
   agencies: null,


### PR DESCRIPTION
- Added ready flag to RequestsLayer init. Should fix map crash resulting from layer updating before `init` is called.

