### PR TITLE
Fixed disappearing NC boundaries

### DIFF
--- a/client/Routes.jsx
+++ b/client/Routes.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Switch, Route, Redirect } from 'react-router-dom';
+import {
+  Switch,
+  Route,
+  Redirect,
+  useLocation,
+} from 'react-router-dom';
+import Box from '@material-ui/core/Box';
 import Desktop from '@components/main/Desktop';
 import Reports from '@components/main/Reports';
 import Privacy from '@components/main/Privacy';
@@ -8,17 +14,23 @@ import Blog from '@components/main/Blog';
 import ContactForm from '@components/main/ContactForm';
 
 export default function Routes() {
+  const { pathname } = useLocation();
+
   return (
-    <Switch>
-      <Route path="/map" component={Desktop} />
-      <Route path="/reports" component={Reports} />
-      <Route path="/privacy" component={Privacy} />
-      <Route path="/faqs" component={Faqs} />
-      <Route path="/blog" component={Blog} />
-      <Route path="/contact" component={ContactForm} />
-      <Route path="/">
-        <Redirect to="map" />
-      </Route>
-    </Switch>
+    <>
+      <Box visibility={pathname !== '/map' ? 'hidden' : 'visible'}>
+        <Desktop />
+      </Box>
+      <Switch>
+        <Route path="/reports" component={Reports} />
+        <Route path="/privacy" component={Privacy} />
+        <Route path="/faqs" component={Faqs} />
+        <Route path="/blog" component={Blog} />
+        <Route path="/contact" component={ContactForm} />
+        <Route path="/">
+          <Redirect to="map" />
+        </Route>
+      </Switch>
+    </>
   );
 }


### PR DESCRIPTION
Fixes #1053 

- Resolves bug causing NC boundaries to disappear after navigating away/back to map page.
- On non-map pages, MapContainer is hidden instead of unmounted. As a result, map does not need to re-render and navigating back is instant without a delay on layers re-drawing.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
