### PR TITLE
Add GitHub/SendGrid config info to .env file for create_release_dev.yml, partially fixing #1099

### DIFF
--- a/.github/workflows/create_release_dev.yml
+++ b/.github/workflows/create_release_dev.yml
@@ -5,6 +5,8 @@ on:
       - dev
     paths:
       - "server/api/**"
+  workflow_dispatch:
+
 jobs:
   build:
     name: Create Docker Image

--- a/.github/workflows/create_release_dev.yml
+++ b/.github/workflows/create_release_dev.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - dev
     paths:
-      - 'server/api/**'
+      - "server/api/**"
 jobs:
   build:
     name: Create Docker Image
@@ -13,11 +13,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1        
+        uses: nelonoel/branch-name@v1.0.1
       - name: Setup environment
         run: |
           echo GITHUB_CODE_VERSION=${{ env.BRANCH_NAME }} >> server/api/.env
           echo GITHUB_SHA=${{ github.sha }} >> server/api/.env
+          echo GITHUB_TOKEN=${{ secrets.GH_ISSUES_TOKEN }} >> server/api/.env
+          echo GITHUB_PROJECT_URL=${{ secrets.GH_PROJECT_URL }} >> server/api/.env
+          echo GITHUB_ISSUES_URL=https://api.github.com/repos/hackforla/311-data-support/issues >> server/api/.env
+          echo SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }} >> server/api/.env
           echo DEBUG=True >> server/api/.env
           echo DB_ECHO=True >> server/api/.env
           echo API_ALLOWED_ORIGINS=[https://dev.311-data.org,http://localhost:3000,https://311-data.matt-webster.net] >> server/api/.env


### PR DESCRIPTION
Partially fixes #1099 

This makes the happy path work successfully on my local environment: upon feedback submission, the server will create a new GH issue, add it to the GH [project](https://github.com/hackforla/311-data-support/projects/1), and send an email to the user using SendGrid.

This does NOT address another issue: if any of these steps fail, the "Submit" button will still be spinning.

![contact-v1-sendgrid](https://user-images.githubusercontent.com/6537426/170367617-89f6a181-8791-4e01-a25e-4f4d4ec92f09.png)

Upon submission, we will need to manually trigger this workflow (which is why I added the `workflow_dispatch`). Then, I believe we will need to update the ecs service for prod (this workflow only updates the dev service), but I can do that in the AWS CLI.

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
