### PR TITLE
1253 request type selector not working

### DIFF
--- a/client/components/Map/Map.jsx
+++ b/client/components/Map/Map.jsx
@@ -178,7 +178,7 @@ class Map extends React.Component {
     if (
       this.state.filterGeo !== prevState.filterGeo ||
       this.state.selectedTypes !== prevState.selectedTypes
-      ) this.map.once('idle', this.setFilteredRequestCounts);
+    ) this.map.once('idle', this.setFilteredRequestCounts);
 
     if (this.props.ncBoundaries != prevProps.ncBoundaries) {
       this.ncLayer.init({
@@ -235,14 +235,14 @@ class Map extends React.Component {
         filterGeo: geo,
         ...(
           center
-          ? {
-            locationInfo: {
-              location: `${center.lat.toFixed(6)} N ${center.lng.toFixed(6)} E`,
-              radius: 1,
-              nc: ncInfoFromLngLat(center),
+            ? {
+              locationInfo: {
+                location: `${center.lat.toFixed(6)} N ${center.lng.toFixed(6)} E`,
+                radius: 1,
+                nc: ncInfoFromLngLat(center),
+              }
             }
-          }
-          : {}
+            : {}
         )
       }),
     });
@@ -335,7 +335,7 @@ class Map extends React.Component {
       const feature = features[i];
 
       if (hoverables.includes(feature.layer.id) && !feature.state.selected) {
-        switch(feature.layer.id) {
+        switch (feature.layer.id) {
           case 'nc-fills':
             this.setState({ address: null });
             updateNcId(feature.properties.council_id);
@@ -367,12 +367,12 @@ class Map extends React.Component {
       updateNcId(result.id);
     } else {
       const address = result.place_name
-                        .split(',')
-                        .slice(0, -2)
-                        .join(', ');
-  
+        .split(',')
+        .slice(0, -2)
+        .join(', ');
+
       getNc({ longitude: result.center[0], latitude: result.center[1] });
-  
+
       this.setState({
         address: address,
       });
@@ -409,7 +409,7 @@ class Map extends React.Component {
   getDistrictCounts = (geoFilterType, filterGeo, selectedTypes) => {
     const { ncCounts, ccCounts } = this.props;
     const { counts, regionId } = (() => {
-      switch(geoFilterType) {
+      switch (geoFilterType) {
         case GEO_FILTER_TYPES.nc: return {
           counts: ncCounts,
           regionId: filterGeo.properties.nc_id,
@@ -534,7 +534,7 @@ class Map extends React.Component {
         <div ref={el => this.requestDetail = el}>
           <RequestDetail requestId={selectedRequestId} />
         </div>
-        { this.state.mapReady && requestTypes && (
+        {this.state.mapReady && requestTypes && (
           <>
             {/* <MapOverview
               date={lastUpdated}
@@ -556,7 +556,7 @@ class Map extends React.Component {
               {
                 (selectedNc || address) && <LocationDetail address={address} nc={selectedNc} />
               }
-              
+
             </div>
             {/* <MapLayers
               selectedTypes={selectedTypes}
@@ -600,4 +600,7 @@ const mapDispatchToProps = dispatch => ({
   updateNcId: id => dispatch(updateNcId(id)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(Map));
+// We need to specify forwardRef to allow refs on connected components.
+// See https://github.com/reduxjs/react-redux/issues/1291#issuecomment-494185126
+// for more info.
+export default connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(withStyles(styles)(Map));

--- a/client/components/Map/layers/RequestsLayer.js
+++ b/client/components/Map/layers/RequestsLayer.js
@@ -21,7 +21,7 @@ function circleColors(requestTypes) {
 
 function typeFilter(selectedTypes) {
   // selectedTypes maps ints (in string form) to booleans, indicating whether the type is selected.
-  // Get an array of int typeIds that only includes typeIds whose corresponding value is true in selectedTypes.
+  // Get an array of int typeIds corresponding value in selectedTypes is true.
   var trueTypes = Object.keys(selectedTypes).map((type) => parseInt(type)).filter((type) => selectedTypes[type]);
   return [
     'in',

--- a/client/components/Map/layers/RequestsLayer.js
+++ b/client/components/Map/layers/RequestsLayer.js
@@ -40,6 +40,7 @@ class RequestsLayer extends React.Component {
   }
 
   componentDidUpdate(prev) {
+    console.log("component did update")
     const {
       activeLayer,
       selectedTypes,
@@ -50,9 +51,10 @@ class RequestsLayer extends React.Component {
     if (activeLayer !== prev.activeLayer)
       this.setActiveLayer(activeLayer);
 
-    if (selectedTypes !== prev.selectedTypes)
+    if (selectedTypes !== prev.selectedTypes) {
+      console.log("selected types changed. new types:" + selectedTypes)
       this.setSelectedTypes(selectedTypes);
-
+    }
     if (requests !== prev.requests && this.ready)
       this.setRequests(requests);
 
@@ -94,7 +96,7 @@ class RequestsLayer extends React.Component {
         'circle-color': circleColors(requestTypes),
         'circle-opacity': 0.8,
       },
-      // filter: typeFilter(selectedTypes),
+      filter: typeFilter(selectedTypes),
     }, BEFORE_ID);
 
     // this.map.addLayer({
@@ -112,7 +114,7 @@ class RequestsLayer extends React.Component {
   };
 
   setActiveLayer = activeLayer => {
-    switch(activeLayer) {
+    switch (activeLayer) {
       case 'points':
         this.map.setLayoutProperty('request-circles', 'visibility', 'visible');
         // this.map.setLayoutProperty('request-heatmap', 'visibility', 'none');
@@ -129,6 +131,7 @@ class RequestsLayer extends React.Component {
   };
 
   setSelectedTypes = selectedTypes => {
+    console.log("setting new requested types")
     this.map.setFilter('request-circles', typeFilter(selectedTypes));
     this.map.setFilter('request-heatmap', typeFilter(selectedTypes));
   };

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8385,7 +8385,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
     "functions-have-names": {
@@ -10549,7 +10549,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json-stringify-safe": {


### PR DESCRIPTION
Fixes #1253

Most of the changed lines are just the autoformatter doing work.

The actual code changes:
1. Make RequestsLayer a connected component such that its prop `selectedTypes` is synchronized with the redux `state.filter.requestTypes`.
2. Fix the typeFilter to operate on an array of typeIds, which is what the MapBox GL API expects.

Here we can see the map with only "Electronic Waste" selected:
![ewaste-only](https://user-images.githubusercontent.com/6537426/176544541-d6e054f4-7036-4f98-a5e9-539e216183ea.png)

And here's the map with all types selected:
![all-types](https://user-images.githubusercontent.com/6537426/176544622-6274797d-fef0-41fe-954b-2c8c11cfad41.png)

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [x] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
