### PR TITLE
1254 status selector not working

### DIFF
--- a/client/components/Map/Map.jsx
+++ b/client/components/Map/Map.jsx
@@ -486,7 +486,6 @@ class Map extends React.Component {
     } = this.props;
 
     const {
-      requests,
       geoFilterType,
       locationInfo,
       // filteredRequestCounts,
@@ -508,7 +507,6 @@ class Map extends React.Component {
       <div className={classes.root} ref={el => this.mapContainer = el} >
         <RequestsLayer
           ref={el => this.requestsLayer = el}
-          requests={requests}
           activeLayer={activeRequestsLayer}
           selectedTypes={selectedTypes}
           colorScheme={colorScheme}

--- a/client/components/Map/index.js
+++ b/client/components/Map/index.js
@@ -31,6 +31,9 @@ class MapContainer extends React.Component {
       selectedTypes: this.getSelectedTypes(),
     }
 
+    // We store the raw requests from the API call here, but eventually they are
+    // converted and stored in the Redux store.
+    this.rawRequests = null;
     this.isSubscribed = null;
   }
 
@@ -49,23 +52,24 @@ class MapContainer extends React.Component {
     this.isSubscribed = false;
   }
 
-  getOpenRequests = async () => {
+  getAllRequests = async () => {
     // TODO: add date specification. See https://dev-api.311-data.org/docs#/default/get_all_service_requests_requests_get.
+    // By default, this will only get the 1000 most recent requests.
     const url = `${process.env.API_URL}/requests`;
     const { data } = await axios.get(url);
-    this.openRequests = data;
+    this.rawRequests = data;
   };
 
   setData = async () => {
     const { pins } = this.props;
 
-    if (!this.openRequests) {
-      await this.getOpenRequests();
+    if (!this.rawRequests) {
+      await this.getAllRequests();
     }
 
     if (this.isSubscribed) {
       const { getDataSuccess } = this.props;
-      getDataSuccess(this.convertRequests(this.openRequests));
+      getDataSuccess(this.convertRequests(this.rawRequests));
     }
   };
 

--- a/client/components/Map/layers/RequestsLayer.js
+++ b/client/components/Map/layers/RequestsLayer.js
@@ -8,14 +8,25 @@ import { connect } from 'react-redux';
 // so you don't cover up important labels
 const BEFORE_ID = 'poi-label';
 
+// Key for type id in store.data.requests.
+const TYPE_ID = 'typeId';
+// Key for closed date in store.data.requests.
+const CLOSED_DATE = 'closedDate';
+
+// Constants required for Mapbox filtering.
+const LITERAL = 'literal';
+const GET = 'get';
+
+const WHITE_HEX = '#FFFFFF';
+
 function circleColors(requestTypes) {
   const colors = [];
   requestTypes.forEach(type => colors.push(type.typeId, type.color))
   return [
     'match',
-    ['get', 'typeId'],
+    [GET, TYPE_ID],
     ...colors,
-    '#FFFFFF',
+    WHITE_HEX,
   ];
 }
 
@@ -25,8 +36,8 @@ function typeFilter(selectedTypes) {
   var trueTypes = Object.keys(selectedTypes).map((type) => parseInt(type)).filter((type) => selectedTypes[type]);
   return [
     'in',
-    ['get', 'typeId'],
-    ['literal', trueTypes]
+    [GET, TYPE_ID],
+    [LITERAL, trueTypes]
   ];
 }
 
@@ -34,16 +45,16 @@ function statusFilter(requestStatus) {
   // requestStatus is an object with keys "open" and "closed", and boolean values.
   if (requestStatus.open && requestStatus.closed) {
     // Hack to allow ALL requests.
-    return ['==', ['literal', "a"], ['literal', "a"]];
+    return ['==', [LITERAL, 'a'], [LITERAL, 'a']];
   }
   if (!requestStatus.open && !requestStatus.closed) {
     // Hack to filter ALL requests.
-    return ['==', ['literal', "a"], ['literal', "b"]];
+    return ['==', [LITERAL, 'a'], [LITERAL, 'b']];
   }
   if (requestStatus.open) {
-    return ['==', ['get', 'closedDate'], ['literal', null]];
+    return ['==', [GET, CLOSED_DATE], [LITERAL, null]];
   }
-  return ['!=', ['get', 'closedDate'], ['literal', null]];
+  return ['!=', [GET, CLOSED_DATE], [LITERAL, null]];
 }
 
 class RequestsLayer extends React.Component {

--- a/client/redux/reducers/data.js
+++ b/client/redux/reducers/data.js
@@ -1,5 +1,6 @@
 export const types = {
   GET_DATA_REQUEST: 'GET_DATA_REQUEST',
+  GET_DATA_REQUEST_SUCCESS: 'GET_DATA_REQUEST_SUCCESS',
   GET_PINS_SUCCESS: 'GET_PINS_SUCCESS',
   GET_PINS_FAILURE: 'GET_PINS_FAILURE',
   GET_OPEN_REQUESTS: 'GET_OPEN_REQUESTS',
@@ -23,6 +24,11 @@ export const types = {
 
 export const getDataRequest = () => ({
   type: types.GET_DATA_REQUEST,
+});
+
+export const getDataRequestSuccess = response => ({
+  type: types.GET_DATA_REQUEST_SUCCESS,
+  payload: response,
 });
 
 export const getPinsSuccess = response => ({
@@ -121,6 +127,11 @@ export default (state = initialState, action) => {
         ...state,
         isMapLoading: true,
         isVisLoading: true,
+      };
+    case types.GET_DATA_REQUEST_SUCCESS:
+      return {
+        ...state,
+        requests: action.payload,
       };
     case types.GET_PINS_SUCCESS:
       return {


### PR DESCRIPTION
Fixes #1254

Major changes:
* stop storing request data as local variable in MapContainer. Instead, add it to the Redux store so that it's easily accessible by RequestsLayer without passing it explicitly.
* change the API call to get both open and closed requests (instead of just open requests). This will continue to be refined, since I will work on fixing the date selector next. Note that this significantly reduces the number of requests that a user would initially see.
* Add filtering logic for open and closed request status in RequestsLayer.
* Compose request status and request type filtering since the Mapbox GL JS API only allows one filter to be applied.

Result of this PR:

All open and closed requests:
![all-reqs](https://user-images.githubusercontent.com/6537426/176820128-4dd2212a-949f-4338-92c6-2ba6b1352035.png)

All closed requests (you can see there aren't many):
![closed-only](https://user-images.githubusercontent.com/6537426/176820173-47257d84-658b-498e-9804-1c8c9e5adef5.png)

All open bulky-item requests:
![open-bulky](https://user-images.githubusercontent.com/6537426/176820150-c3f8d152-0510-4c0e-b7d3-7c091f69ac85.png)


  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
