### PR TITLE
1252 make date selector work beyond week

### DIFF
--- a/client/redux/reducers/data.js
+++ b/client/redux/reducers/data.js
@@ -137,11 +137,16 @@ export default (state = initialState, action) => {
         isMapLoading: true,
         isVisLoading: true,
       };
-    case types.GET_DATA_REQUEST_SUCCESS:
+    case types.GET_DATA_REQUEST_SUCCESS: {
+      const newRequests = {
+        type: 'FeatureCollection',
+        features: [...state.requests.features, ...action.payload],
+      };
       return {
         ...state,
-        requests: action.payload,
+        requests: newRequests,
       };
+    }
     case types.UPDATE_DATE_RANGES:
       return {
         ...state,

--- a/client/redux/reducers/data.js
+++ b/client/redux/reducers/data.js
@@ -1,6 +1,7 @@
 export const types = {
   GET_DATA_REQUEST: 'GET_DATA_REQUEST',
   GET_DATA_REQUEST_SUCCESS: 'GET_DATA_REQUEST_SUCCESS',
+  UPDATE_DATE_RANGES: 'UPDATE_DATE_RANGES',
   GET_PINS_SUCCESS: 'GET_PINS_SUCCESS',
   GET_PINS_FAILURE: 'GET_PINS_FAILURE',
   GET_OPEN_REQUESTS: 'GET_OPEN_REQUESTS',
@@ -29,6 +30,11 @@ export const getDataRequest = () => ({
 export const getDataRequestSuccess = response => ({
   type: types.GET_DATA_REQUEST_SUCCESS,
   payload: response,
+});
+
+export const updateDateRanges = dateRanges => ({
+  type: types.UPDATE_DATE_RANGES,
+  payload: dateRanges,
 });
 
 export const getPinsSuccess = response => ({
@@ -120,6 +126,7 @@ const initialState = {
   selectedNcId: null,
   // Empty GeoJSON object.
   requests: { type: 'FeatureCollection', features: [] },
+  dateRangesWithRequests: [],
 };
 
 export default (state = initialState, action) => {
@@ -134,6 +141,11 @@ export default (state = initialState, action) => {
       return {
         ...state,
         requests: action.payload,
+      };
+    case types.UPDATE_DATE_RANGES:
+      return {
+        ...state,
+        dateRangesWithRequests: action.payload,
       };
     case types.GET_PINS_SUCCESS:
       return {


### PR DESCRIPTION
Fixes #1252 

Major changes:
* store date ranges for which we have request data in the Redux store
* when the user changes the date range, check the new date range against the current date ranges that we have data for. Only retrieve data from date ranges which aren't covered.

Note: it is still very slow to get data for a whole month, even though we are making the API requests in parallel: 25s on my local frontend. It might be faster on the actual dev site. But there is no loading modal or anything like that. We'll need to implement that, and try to speed up the server as well.

Note 2: The ReactDayPicker is not very intuitive to use. It will update the date range right after the start date is selected, even though an end date is not selected yet. This will need to be fixed.

Here we can see the density of requests over the past month, totaling 82k requests.
![requests-one-month](https://user-images.githubusercontent.com/6537426/179074417-25278064-f800-4645-9ece-330e9c93ca60.png)

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
