### PR TITLE
1283 date range selector should display the date range for the past week by default

### DIFF
--- a/client/components/DateSelector/DateSelector.jsx
+++ b/client/components/DateSelector/DateSelector.jsx
@@ -15,19 +15,28 @@ import DateRanges from './DateRanges';
 const dateFormat = 'YYYY-MM-DD';
 
 function DateSelector({
+  onRangeSelect,
   range,
+  initialDates,
   updateStartDate,
   updateEndDate,
 }) {
+  const [dates, setDates] = useState(initialDates);
   const [expanded, setExpanded] = useState(false);
   const classes = useStyles();
 
   const handleOptionSelect = optionDates => {
     const formattedStart = moment(optionDates[0]).format(dateFormat);
     const formattedEnd = moment(optionDates[1]).format(dateFormat);
+    setDates(() => optionDates);
     updateStartDate(formattedStart);
     updateEndDate(formattedEnd);
     setExpanded(false);
+  };
+
+  const handleDateSelect = selectedDays => {
+    setDates(() => selectedDays);
+    if (typeof onRangeSelect === 'function') onRangeSelect(selectedDays);
   };
 
   const closeOptionsOnDateToggle = useCallback(() => {
@@ -44,7 +53,9 @@ function DateSelector({
           <div className={classes.selector}>
             <DatePicker
               range={range}
+              dates={dates}
               onToggle={closeOptionsOnDateToggle}
+              onSelect={handleDateSelect}
             />
             <div className={classes.separator} />
           </div>
@@ -54,6 +65,7 @@ function DateSelector({
             classes={{ option, selected }}
             options={options}
             onSelect={handleOptionSelect}
+            dates={dates}
           />
         </SelectorBox.Collapse>
       </SelectorBox>
@@ -70,10 +82,14 @@ export default connect(null, mapDispatchToProps)(DateSelector);
 
 DateSelector.propTypes = {
   range: PropTypes.bool,
+  onRangeSelect: PropTypes.func,
+  initialDates: PropTypes.arrayOf(Date),
   updateStartDate: PropTypes.func.isRequired,
   updateEndDate: PropTypes.func.isRequired,
 };
 
 DateSelector.defaultProps = {
   range: false,
+  onRangeSelect: null,
+  initialDates: [],
 };

--- a/client/components/DateSelector/DateSelector.jsx
+++ b/client/components/DateSelector/DateSelector.jsx
@@ -15,28 +15,19 @@ import DateRanges from './DateRanges';
 const dateFormat = 'YYYY-MM-DD';
 
 function DateSelector({
-  onRangeSelect,
   range,
-  initialDates,
   updateStartDate,
   updateEndDate,
 }) {
-  const [dates, setDates] = useState(initialDates);
   const [expanded, setExpanded] = useState(false);
   const classes = useStyles();
 
   const handleOptionSelect = optionDates => {
     const formattedStart = moment(optionDates[0]).format(dateFormat);
     const formattedEnd = moment(optionDates[1]).format(dateFormat);
-    setDates(() => optionDates);
     updateStartDate(formattedStart);
     updateEndDate(formattedEnd);
     setExpanded(false);
-  };
-
-  const handleDateSelect = selectedDays => {
-    setDates(() => selectedDays);
-    if (typeof onRangeSelect === 'function') onRangeSelect(selectedDays);
   };
 
   const closeOptionsOnDateToggle = useCallback(() => {
@@ -53,9 +44,7 @@ function DateSelector({
           <div className={classes.selector}>
             <DatePicker
               range={range}
-              dates={dates}
               onToggle={closeOptionsOnDateToggle}
-              onSelect={handleDateSelect}
             />
             <div className={classes.separator} />
           </div>
@@ -65,7 +54,6 @@ function DateSelector({
             classes={{ option, selected }}
             options={options}
             onSelect={handleOptionSelect}
-            dates={dates}
           />
         </SelectorBox.Collapse>
       </SelectorBox>
@@ -82,14 +70,10 @@ export default connect(null, mapDispatchToProps)(DateSelector);
 
 DateSelector.propTypes = {
   range: PropTypes.bool,
-  onRangeSelect: PropTypes.func,
-  initialDates: PropTypes.arrayOf(Date),
   updateStartDate: PropTypes.func.isRequired,
   updateEndDate: PropTypes.func.isRequired,
 };
 
 DateSelector.defaultProps = {
   range: false,
-  onRangeSelect: null,
-  initialDates: [],
 };

--- a/client/components/common/DatePicker/DatePicker.jsx
+++ b/client/components/common/DatePicker/DatePicker.jsx
@@ -1,6 +1,7 @@
 import React, {
   useRef, useState, useEffect, useCallback,
 } from 'react';
+import { connect } from 'react-redux';
 import ReactDayPicker from '@components/common/ReactDayPicker';
 import PropTypes from 'prop-types';
 import CalendarIcon from '@material-ui/icons/CalendarToday';
@@ -44,6 +45,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const renderSelectedDays = (dates, classes, range) => {
+  console.log('dates are ', dates);
   const [from, to] = dates;
   const isFromSelected = Boolean(from);
   const isBothSelected = Boolean(from && to);
@@ -79,9 +81,8 @@ const renderSelectedDays = (dates, classes, range) => {
 };
 
 const DatePicker = ({
-  dates, onSelect, open, onToggle, range,
+  open, onToggle, range, startDate, endDate,
 }) => {
-  const [selectedDays, setSelectedDays] = useState(() => dates);
   const [showCalendar, setShowCalendar] = useState(() => open);
   const classes = useStyles();
 
@@ -92,10 +93,6 @@ const DatePicker = ({
   useEffect(() => {
     setShowCalendar(false);
   }, [open]);
-
-  useEffect(() => {
-    setSelectedDays(() => dates);
-  }, [dates]);
 
   const getCoordinates = () => {
     if (ref.current) {
@@ -113,15 +110,9 @@ const DatePicker = ({
     setShowCalendar(prevState => !prevState);
     if (onToggle) onToggle();
   };
-
-  const handleDateChage = incomingDates => {
-    setSelectedDays(() => incomingDates);
-    if (onSelect) onSelect(incomingDates);
-  };
-
   return (
     <div ref={ref} className={classes.selector}>
-      <div>{renderSelectedDays(selectedDays, classes, range)}</div>
+      <div>{renderSelectedDays([startDate, endDate], classes, range)}</div>
       <IconButton
         className={classes.button}
         aria-label="toggle calendar datepicker"
@@ -135,8 +126,6 @@ const DatePicker = ({
         {showCalendar ? (
           <ReactDayPicker
             range={range}
-            initialDates={selectedDays}
-            onChange={handleDateChage}
           />
         ) : null}
       </div>
@@ -145,19 +134,24 @@ const DatePicker = ({
 };
 
 DatePicker.propTypes = {
-  onSelect: PropTypes.func,
   range: PropTypes.bool,
   open: PropTypes.bool,
   onToggle: PropTypes.func,
-  dates: PropTypes.arrayOf(Date),
+  startDate: PropTypes.string,
+  endDate: PropTypes.string,
 };
 
 DatePicker.defaultProps = {
   open: false,
   range: false,
   onToggle: null,
-  onSelect: null,
-  dates: [],
+  startDate: null,
+  endDate: null,
 };
 
-export default DatePicker;
+const mapStateToProps = state => ({
+  startDate: state.filters.startDate,
+  endDate: state.filters.endDate,
+});
+
+export default connect(mapStateToProps)(ReactDayPicker);

--- a/client/components/common/DatePicker/DatePicker.jsx
+++ b/client/components/common/DatePicker/DatePicker.jsx
@@ -1,7 +1,6 @@
 import React, {
   useRef, useState, useEffect, useCallback,
 } from 'react';
-import { connect } from 'react-redux';
 import ReactDayPicker from '@components/common/ReactDayPicker';
 import PropTypes from 'prop-types';
 import CalendarIcon from '@material-ui/icons/CalendarToday';
@@ -45,7 +44,6 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const renderSelectedDays = (dates, classes, range) => {
-  console.log('dates are ', dates);
   const [from, to] = dates;
   const isFromSelected = Boolean(from);
   const isBothSelected = Boolean(from && to);
@@ -81,8 +79,9 @@ const renderSelectedDays = (dates, classes, range) => {
 };
 
 const DatePicker = ({
-  open, onToggle, range, startDate, endDate,
+  dates, onSelect, open, onToggle, range,
 }) => {
+  const [selectedDays, setSelectedDays] = useState(() => dates);
   const [showCalendar, setShowCalendar] = useState(() => open);
   const classes = useStyles();
 
@@ -93,6 +92,10 @@ const DatePicker = ({
   useEffect(() => {
     setShowCalendar(false);
   }, [open]);
+
+  useEffect(() => {
+    setSelectedDays(() => dates);
+  }, [dates]);
 
   const getCoordinates = () => {
     if (ref.current) {
@@ -110,9 +113,15 @@ const DatePicker = ({
     setShowCalendar(prevState => !prevState);
     if (onToggle) onToggle();
   };
+
+  const handleDateChage = incomingDates => {
+    setSelectedDays(() => incomingDates);
+    if (onSelect) onSelect(incomingDates);
+  };
+
   return (
     <div ref={ref} className={classes.selector}>
-      <div>{renderSelectedDays([startDate, endDate], classes, range)}</div>
+      <div>{renderSelectedDays(selectedDays, classes, range)}</div>
       <IconButton
         className={classes.button}
         aria-label="toggle calendar datepicker"
@@ -126,6 +135,8 @@ const DatePicker = ({
         {showCalendar ? (
           <ReactDayPicker
             range={range}
+            initialDates={selectedDays}
+            onChange={handleDateChage}
           />
         ) : null}
       </div>
@@ -134,24 +145,19 @@ const DatePicker = ({
 };
 
 DatePicker.propTypes = {
+  onSelect: PropTypes.func,
   range: PropTypes.bool,
   open: PropTypes.bool,
   onToggle: PropTypes.func,
-  startDate: PropTypes.string,
-  endDate: PropTypes.string,
+  dates: PropTypes.arrayOf(Date),
 };
 
 DatePicker.defaultProps = {
   open: false,
   range: false,
   onToggle: null,
-  startDate: null,
-  endDate: null,
+  onSelect: null,
+  dates: [],
 };
 
-const mapStateToProps = state => ({
-  startDate: state.filters.startDate,
-  endDate: state.filters.endDate,
-});
-
-export default connect(mapStateToProps)(ReactDayPicker);
+export default DatePicker;

--- a/client/components/common/DatePicker/DatePicker.jsx
+++ b/client/components/common/DatePicker/DatePicker.jsx
@@ -1,6 +1,8 @@
 import React, {
   useRef, useState, useEffect, useCallback,
 } from 'react';
+import { connect } from 'react-redux';
+import moment from 'moment';
 import ReactDayPicker from '@components/common/ReactDayPicker';
 import PropTypes from 'prop-types';
 import CalendarIcon from '@material-ui/icons/CalendarToday';
@@ -52,9 +54,9 @@ const renderSelectedDays = (dates, classes, range) => {
 
   if (isBothSelected) {
     selectedDaysElements.push(
-      <span key="from">{from.toLocaleDateString('en-US')}</span>,
+      <span key="from">{moment(from).format('L')}</span>,
       <span key="delimiter"> - </span>,
-      <span key="to">{to.toLocaleDateString('en-US')}</span>,
+      <span key="to">{moment(to).format('L')}</span>,
     );
     return selectedDaysElements;
   }
@@ -62,7 +64,7 @@ const renderSelectedDays = (dates, classes, range) => {
     selectedDaysElements.push(
       <span key="from">
         {' '}
-        {from.toLocaleDateString('en-US')}
+        {moment(from).format('L')}
         {' '}
       </span>,
     );
@@ -79,9 +81,8 @@ const renderSelectedDays = (dates, classes, range) => {
 };
 
 const DatePicker = ({
-  dates, onSelect, open, onToggle, range,
+  open, onToggle, range, startDate, endDate,
 }) => {
-  const [selectedDays, setSelectedDays] = useState(() => dates);
   const [showCalendar, setShowCalendar] = useState(() => open);
   const classes = useStyles();
 
@@ -92,10 +93,6 @@ const DatePicker = ({
   useEffect(() => {
     setShowCalendar(false);
   }, [open]);
-
-  useEffect(() => {
-    setSelectedDays(() => dates);
-  }, [dates]);
 
   const getCoordinates = () => {
     if (ref.current) {
@@ -113,15 +110,9 @@ const DatePicker = ({
     setShowCalendar(prevState => !prevState);
     if (onToggle) onToggle();
   };
-
-  const handleDateChage = incomingDates => {
-    setSelectedDays(() => incomingDates);
-    if (onSelect) onSelect(incomingDates);
-  };
-
   return (
     <div ref={ref} className={classes.selector}>
-      <div>{renderSelectedDays(selectedDays, classes, range)}</div>
+      <div>{renderSelectedDays([startDate, endDate], classes, range)}</div>
       <IconButton
         className={classes.button}
         aria-label="toggle calendar datepicker"
@@ -135,8 +126,6 @@ const DatePicker = ({
         {showCalendar ? (
           <ReactDayPicker
             range={range}
-            initialDates={selectedDays}
-            onChange={handleDateChage}
           />
         ) : null}
       </div>
@@ -145,19 +134,24 @@ const DatePicker = ({
 };
 
 DatePicker.propTypes = {
-  onSelect: PropTypes.func,
   range: PropTypes.bool,
   open: PropTypes.bool,
   onToggle: PropTypes.func,
-  dates: PropTypes.arrayOf(Date),
+  startDate: PropTypes.string,
+  endDate: PropTypes.string,
 };
 
 DatePicker.defaultProps = {
   open: false,
   range: false,
   onToggle: null,
-  onSelect: null,
-  dates: [],
+  startDate: null,
+  endDate: null,
 };
 
-export default DatePicker;
+const mapStateToProps = state => ({
+  startDate: state.filters.startDate,
+  endDate: state.filters.endDate,
+});
+
+export default connect(mapStateToProps)(DatePicker);

--- a/client/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/client/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -26,7 +26,7 @@ const getInitialState = initialDates => {
 const defaultState = { from: null, to: null };
 
 function ReactDayPicker({
-  initialDates, range, updateStartDate,
+  onChange, initialDates, range, updateStartDate,
   updateEndDate,
 }) {
   const [state, setState] = useState(getInitialState(initialDates));
@@ -39,6 +39,7 @@ function ReactDayPicker({
 
   const resetDays = () => {
     setState(defaultState);
+    onChange([]);
   };
 
   const setFromDay = day => {
@@ -48,6 +49,7 @@ function ReactDayPicker({
       enteredTo: null,
     }));
     updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
+    onChange([day]);
   };
 
   const setFromToDay = day => {
@@ -57,6 +59,7 @@ function ReactDayPicker({
       enteredTo: day,
     }));
     updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
+    onChange([state.from, day]);
   };
 
   const handleDayClick = day => {
@@ -114,6 +117,7 @@ function ReactDayPicker({
 
 ReactDayPicker.propTypes = {
   range: PropTypes.bool,
+  onChange: PropTypes.func,
   initialDates: PropTypes.arrayOf(Date),
   updateStartDate: PropTypes.func,
   updateEndDate: PropTypes.func,
@@ -121,6 +125,7 @@ ReactDayPicker.propTypes = {
 
 ReactDayPicker.defaultProps = {
   range: false,
+  onChange: null,
   initialDates: [],
   updateStartDate: null,
   updateEndDate: null,

--- a/client/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/client/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -26,9 +26,10 @@ const getInitialState = initialDates => {
 const defaultState = { from: null, to: null };
 
 function ReactDayPicker({
-  onChange, initialDates, range, updateStartDate,
+  initialDates, range, updateStartDate,
   updateEndDate,
 }) {
+  // TODO: consider getting rid of this local date state in favor of Redux.
   const [state, setState] = useState(getInitialState(initialDates));
 
   const isSelectingFirstDay = (from, to, day) => {
@@ -39,7 +40,6 @@ function ReactDayPicker({
 
   const resetDays = () => {
     setState(defaultState);
-    onChange([]);
   };
 
   const setFromDay = day => {
@@ -49,7 +49,6 @@ function ReactDayPicker({
       enteredTo: null,
     }));
     updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
-    onChange([day]);
   };
 
   const setFromToDay = day => {
@@ -59,7 +58,6 @@ function ReactDayPicker({
       enteredTo: day,
     }));
     updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
-    onChange([state.from, day]);
   };
 
   const handleDayClick = day => {
@@ -117,7 +115,6 @@ function ReactDayPicker({
 
 ReactDayPicker.propTypes = {
   range: PropTypes.bool,
-  onChange: PropTypes.func,
   initialDates: PropTypes.arrayOf(Date),
   updateStartDate: PropTypes.func,
   updateEndDate: PropTypes.func,
@@ -125,7 +122,6 @@ ReactDayPicker.propTypes = {
 
 ReactDayPicker.defaultProps = {
   range: false,
-  onChange: null,
   initialDates: [],
   updateStartDate: null,
   updateEndDate: null,

--- a/client/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/client/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -26,7 +26,7 @@ const getInitialState = initialDates => {
 const defaultState = { from: null, to: null };
 
 function ReactDayPicker({
-  onChange, initialDates, range, updateStartDate,
+  initialDates, range, updateStartDate,
   updateEndDate,
 }) {
   const [state, setState] = useState(getInitialState(initialDates));
@@ -39,7 +39,6 @@ function ReactDayPicker({
 
   const resetDays = () => {
     setState(defaultState);
-    onChange([]);
   };
 
   const setFromDay = day => {
@@ -49,7 +48,6 @@ function ReactDayPicker({
       enteredTo: null,
     }));
     updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
-    onChange([day]);
   };
 
   const setFromToDay = day => {
@@ -59,7 +57,6 @@ function ReactDayPicker({
       enteredTo: day,
     }));
     updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
-    onChange([state.from, day]);
   };
 
   const handleDayClick = day => {
@@ -117,7 +114,6 @@ function ReactDayPicker({
 
 ReactDayPicker.propTypes = {
   range: PropTypes.bool,
-  onChange: PropTypes.func,
   initialDates: PropTypes.arrayOf(Date),
   updateStartDate: PropTypes.func,
   updateEndDate: PropTypes.func,
@@ -125,7 +121,6 @@ ReactDayPicker.propTypes = {
 
 ReactDayPicker.defaultProps = {
   range: false,
-  onChange: null,
   initialDates: [],
   updateStartDate: null,
   updateEndDate: null,


### PR DESCRIPTION
Fixes #1283

The `DatePicker` was not showing the default date range of the past week since it was relying on local state to render the date range, instead of relying on the date range in the Redux store. This PR gets rid of local date state in most of our date-related components, and makes the `DatePicker` use the dates from the Redux store.

Now we can see that the default of 1 week is shown in the date range when the user opens the app:
![default-date-range](https://user-images.githubusercontent.com/6537426/181074832-f4f148f4-a192-459a-b15b-b86f385a1fc4.png)


  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
