### PR TITLE
1282 reactdaypicker updates date ranges when only start date is selected

### DIFF
--- a/client/components/Map/index.js
+++ b/client/components/Map/index.js
@@ -50,7 +50,8 @@ class MapContainer extends React.Component {
   componentDidUpdate(prevProps) {
     const { activeMode, pins, startDate, endDate } = this.props;
     // Note: we are only checking if the endDate has changed, not the startDate.
-    // This is so that we don't get data until the user has selected an endDate.
+    // This is so that we don't attempt to get new data until the user has
+    // selected an endDate.
     if (prevProps.activeMode !== activeMode || prevProps.pins !== pins ||
       prevProps.endDate != endDate && endDate != null) {
       this.setData();
@@ -82,6 +83,9 @@ class MapContainer extends React.Component {
     // If date range A starts before date range B, then it has a subrange that
     // does not overlap with B.
     if (momentStartA < momentStartB){
+      // For the left side, we want to choose the earlier of (startB, endA).
+      // If startB is earlier than endA, that means A and B overlap, so we
+      // subtract 1 day from startB, since it's already included in A.
       const leftNonOverlapEnd = momentStartB < momentEndA ? momentStartB.subtract(1, 'days') : momentEndA;
       leftNonOverlap = [startA,
         leftNonOverlapEnd.format(INTERNAL_DATE_SPEC)];

--- a/client/components/Map/index.js
+++ b/client/components/Map/index.js
@@ -49,8 +49,10 @@ class MapContainer extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { activeMode, pins, startDate, endDate } = this.props;
+    // Note: we are only checking if the endDate has changed, not the startDate.
+    // This is so that we don't get data until the user has selected an endDate.
     if (prevProps.activeMode !== activeMode || prevProps.pins !== pins ||
-      prevProps.startDate != startDate || prevProps.endDate != endDate) {
+      prevProps.endDate != endDate && endDate != null) {
       this.setData();
     }
   }
@@ -72,16 +74,23 @@ class MapContainer extends React.Component {
   getNonOverlappingRanges = (startA, endA, startB, endB) => {
     var leftNonOverlap = null;
     var rightNonOverlap = null;
+    const momentStartA = moment(startA);
+    const momentEndA = moment(endA);
+    const momentStartB = moment(startB);
+    const momentEndB = moment(endB);
+
     // If date range A starts before date range B, then it has a subrange that
     // does not overlap with B.
-    if (moment(startA) < moment(startB)){
+    if (momentStartA < momentStartB){
+      const leftNonOverlapEnd = momentStartB < momentEndA ? momentStartB.subtract(1, 'days') : momentEndA;
       leftNonOverlap = [startA,
-        moment(startB).subtract(1, 'days').format(INTERNAL_DATE_SPEC)];
+        leftNonOverlapEnd.format(INTERNAL_DATE_SPEC)];
     }
     // If date range A ends after date range B, then it has a subrange that does
     // not overlap with B.
-    if (moment(endB) < moment(endA)){
-      rightNonOverlap = [moment(endB).add(1, 'days').format(INTERNAL_DATE_SPEC),
+    if (momentEndB < momentEndA){
+      var rightNonOverlapStart = momentEndB < momentStartA ? momentStartA : momentEndB.add(1, 'days'); 
+      rightNonOverlap = [rightNonOverlapStart.format(INTERNAL_DATE_SPEC),
         endA];
     }
     return [leftNonOverlap, rightNonOverlap];
@@ -162,8 +171,8 @@ class MapContainer extends React.Component {
         currentEnd = dateRange[1];
       } else {
         resolvedDateRanges.push([currentStart, currentEnd]);
-        currentStart = null;
-        currentEnd = null;
+        currentStart = dateRange[0];
+        currentEnd = dateRange[1];
       }
     }
     if (currentStart !== null){

--- a/client/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/client/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -7,29 +7,25 @@ import {
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import DayPicker, { DateUtils } from 'react-day-picker';
+import DayPicker from 'react-day-picker';
 import { connect } from 'react-redux';
 
 import { INTERNAL_DATE_SPEC } from '../CONSTANTS';
 import Styles from './Styles';
 import WeekDay from './Weekday';
 
+/** A wrapper around react-day-picker that selects a date range. */
 function ReactDayPicker({
   range, updateStartDate, updateEndDate, startDate, endDate,
 }) {
+  // enteredTo represents the day that the user is currently hovering over.
   const [enteredTo, setEnteredTo] = useState(endDate);
-  const isSelectingFirstDay = (from, to, day) => {
-    const isBeforeFirstDay = from && DateUtils.isDayBefore(moment(day).toDate(),
-      moment(from).toDate());
-    const isRangeSelected = from && to;
-    return !from || isBeforeFirstDay || isRangeSelected;
-  };
 
   const setFromDay = day => {
     updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
   };
 
-  const setFromToDay = day => {
+  const setToDay = day => {
     updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
   };
 
@@ -39,28 +35,28 @@ function ReactDayPicker({
       return;
     }
 
-    if (startDate && endDate) {
-      setFromDay(day);
-      updateEndDate(null);
-      setEnteredTo(null);
+    // Our date range selection logic is very simple: the user is selecting the
+    // first day in their date range if from and to are set, or if they're both
+    // unset. Otherwise, they are selecting the last day.
+    if (!(startDate && endDate)) {
+      setToDay(day);
       return;
     }
-
-    if (isSelectingFirstDay(startDate, endDate, day)) {
-      setFromDay(day);
-    } else {
-      setFromToDay(day);
-    }
+    setFromDay(day);
+    updateEndDate(null);
+    setEnteredTo(null);
   };
 
   const handleDayMouseEnter = day => {
     if (!range) return;
-    if (!isSelectingFirstDay(startDate, endDate, day)) {
+    if (startDate && !endDate) {
       setEnteredTo(day);
     }
   };
+
   const from = moment(startDate).toDate();
   const enteredToDate = moment(enteredTo).toDate();
+
   return (
     <>
       <Styles range={range} />
@@ -69,7 +65,6 @@ function ReactDayPicker({
         numberOfMonths={1}
         fromMonth={from}
         selectedDays={[from, { from, to: enteredToDate }]}
-        disabledDays={{ ...(range && { before: from }) }}
         modifiers={{ start: from, end: enteredToDate }}
         onDayClick={handleDayClick}
         onDayMouseEnter={handleDayMouseEnter}

--- a/client/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/client/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -14,49 +14,22 @@ import { INTERNAL_DATE_SPEC } from '../CONSTANTS';
 import Styles from './Styles';
 import WeekDay from './Weekday';
 
-const getInitialState = initialDates => {
-  const [from, to] = initialDates;
-  return {
-    from,
-    to,
-    enteredTo: to, // Keep track of the last day for mouseEnter.
-  };
-};
-
-const defaultState = { from: null, to: null };
-
 function ReactDayPicker({
-  initialDates, range, updateStartDate,
-  updateEndDate,
+  range, updateStartDate, updateEndDate, startDate, endDate,
 }) {
-  // TODO: consider getting rid of this local date state in favor of Redux.
-  const [state, setState] = useState(getInitialState(initialDates));
-
+  const [enteredTo, setEnteredTo] = useState(endDate);
   const isSelectingFirstDay = (from, to, day) => {
-    const isBeforeFirstDay = from && DateUtils.isDayBefore(day, from);
+    const isBeforeFirstDay = from && DateUtils.isDayBefore(moment(day).toDate(),
+      moment(from).toDate());
     const isRangeSelected = from && to;
     return !from || isBeforeFirstDay || isRangeSelected;
   };
 
-  const resetDays = () => {
-    setState(defaultState);
-  };
-
   const setFromDay = day => {
-    setState(() => ({
-      from: day,
-      to: null,
-      enteredTo: null,
-    }));
     updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
   };
 
   const setFromToDay = day => {
-    setState(prevState => ({
-      ...prevState,
-      to: day,
-      enteredTo: day,
-    }));
     updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
   };
 
@@ -66,16 +39,14 @@ function ReactDayPicker({
       return;
     }
 
-    const { from, to } = state;
-    const dayIsInSelectedRange = from && to && day >= from && day <= to;
-    const sameDaySelected = from ? day.getTime() === from.getTime() : false;
-
-    if (dayIsInSelectedRange || sameDaySelected) {
-      resetDays();
+    if (startDate && endDate) {
+      setFromDay(day);
+      updateEndDate(null);
+      setEnteredTo(null);
       return;
     }
 
-    if (isSelectingFirstDay(from, to, day)) {
+    if (isSelectingFirstDay(startDate, endDate, day)) {
       setFromDay(day);
     } else {
       setFromToDay(day);
@@ -84,17 +55,12 @@ function ReactDayPicker({
 
   const handleDayMouseEnter = day => {
     if (!range) return;
-    const { from, to } = state;
-    if (!isSelectingFirstDay(from, to, day)) {
-      setState(prevState => ({
-        ...prevState,
-        enteredTo: day,
-      }));
+    if (!isSelectingFirstDay(startDate, endDate, day)) {
+      setEnteredTo(day);
     }
   };
-
-  const { from, enteredTo } = state;
-
+  const from = moment(startDate).toDate();
+  const enteredToDate = moment(enteredTo).toDate();
   return (
     <>
       <Styles range={range} />
@@ -102,9 +68,9 @@ function ReactDayPicker({
         className="Range"
         numberOfMonths={1}
         fromMonth={from}
-        selectedDays={[from, { from, to: enteredTo }]}
+        selectedDays={[from, { from, to: enteredToDate }]}
         disabledDays={{ ...(range && { before: from }) }}
-        modifiers={{ start: from, end: enteredTo }}
+        modifiers={{ start: from, end: enteredToDate }}
         onDayClick={handleDayClick}
         onDayMouseEnter={handleDayMouseEnter}
         weekdayElement={<WeekDay />}
@@ -115,16 +81,18 @@ function ReactDayPicker({
 
 ReactDayPicker.propTypes = {
   range: PropTypes.bool,
-  initialDates: PropTypes.arrayOf(Date),
   updateStartDate: PropTypes.func,
   updateEndDate: PropTypes.func,
+  startDate: PropTypes.string,
+  endDate: PropTypes.string,
 };
 
 ReactDayPicker.defaultProps = {
   range: false,
-  initialDates: [],
   updateStartDate: null,
   updateEndDate: null,
+  startDate: null,
+  endDate: null,
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -132,4 +100,9 @@ const mapDispatchToProps = dispatch => ({
   updateEndDate: date => dispatch(reduxUpdateEndDate(date)),
 });
 
-export default connect(null, mapDispatchToProps)(ReactDayPicker);
+const mapStateToProps = state => ({
+  startDate: state.filters.startDate,
+  endDate: state.filters.endDate,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ReactDayPicker);


### PR DESCRIPTION
Fixes #1282

- Significantly simplify the way that we pick date ranges in ReactDayPicker. By default, a date range (past week) is already selected. When a date range is already selected and the user clicks on a new date, we don't perform any logic to attempt to preserve the start or end date; we just create an entirely new date range, starting from the date that the user clicked on.
- Update index.js to only retrieve new data when the end date has changed (not start date).

This also fixes a couple bugs around pulling data for new date ranges, in index.js.
- When getting the non-overlapping ranges for two ranges A and B, we need to check whether A and B overlap. This will make a difference in the non-overlapping range.
- When we are resolving the date ranges, if we find that the next date range doesn't overlap with our current one, we need to add the current one to our list of date ranges and then set the new current date range to be the next one.

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
