### PR TITLE
ignore snapshots and /coverage/ directories in .gitignore

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -9,3 +9,7 @@ node_modules_non_es5
 dist/
 
 webpack-stats.json
+
+# testing
+__snapshots__
+/coverage/


### PR DESCRIPTION
 update .gitignore to ignore snapshots and /coverage/ directories from getting added to the repo

Fixes #1345

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
