### PR TITLE
Fixes: Contact form submit button does not show up when screen resolution height <= 690px

### DIFF
--- a/client/components/Footer.jsx
+++ b/client/components/Footer.jsx
@@ -9,7 +9,7 @@ import SocialMediaLinks from './SocialMediaLinks';
 
 const useStyles = makeStyles(theme => ({
   footer: {
-    position: 'sticky',
+    position: 'fixed',
     bottom: 0,
     height: theme.footer.height,
     width: '100%',

--- a/client/components/contact/ContactForm.jsx
+++ b/client/components/contact/ContactForm.jsx
@@ -9,8 +9,15 @@ import {
   Button,
   TextField,
   CircularProgress,
+  makeStyles,
 } from '@material-ui/core';
 import 'react-toastify/dist/ReactToastify.css';
+
+const useStyles = makeStyles(theme => ({
+  footer: {
+    height: theme.footer.height,
+  },
+}));
 
 const initialFormValues = {
   firstName: '',
@@ -39,6 +46,8 @@ const toastEmitterSettings = {
 };
 
 const ContactForm = () => {
+  const classes = useStyles();
+
   const dispatch = useDispatch();
 
   // mapStateToProps equivalent.
@@ -251,6 +260,7 @@ const ContactForm = () => {
               Submit
             </Button>
           </Grid>
+          <Grid container direction="column" alignItems="center" justifyContent="center" className={classes.footer} />
         </Grid>
       </form>
     </Container>


### PR DESCRIPTION
Needed to prevent submit button from being covered by footer on contact form when vertical scrolling is required. Also, changed footer positioning back from 'sticky' to 'fixed' so the footer does not move up with content

Fixes #1340

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
