### PR TITLE
update reports links to new dashboards

### DIFF
--- a/client/components/Header.jsx
+++ b/client/components/Header.jsx
@@ -81,29 +81,14 @@ const Header = () => {
             horizontal: 'left',
           }}
         >
-          <Link to="/reports/dashboards/overview" className={classes.link}>
+          <Link to="/reports/dashboards/overview_combined" className={classes.link}>
             <MenuItem onClick={handleClose} button className={classes.button}>
               Overview
             </MenuItem>
           </Link>
-          <Link to="/reports/dashboards/recent" className={classes.link}>
+          <Link to="/reports/dashboards/nc_summary_comparison" className={classes.link}>
             <MenuItem onClick={handleClose} button className={classes.button}>
-              Recent
-            </MenuItem>
-          </Link>
-          <Link to="/reports/dashboards/neighborhood" className={classes.link}>
-            <MenuItem onClick={handleClose} button className={classes.button}>
-              Neighborhood
-            </MenuItem>
-          </Link>
-          <Link to="/reports/dashboards/neighborhood_recent" className={classes.link}>
-            <MenuItem onClick={handleClose} button className={classes.button}>
-              Neighborhood Recent
-            </MenuItem>
-          </Link>
-          <Link to="/reports/dashboards/types_map" className={classes.link}>
-            <MenuItem onClick={handleClose} button className={classes.button}>
-              Request Type Map
+              Compare Two Neighborhoods
             </MenuItem>
           </Link>
         </Menu>


### PR DESCRIPTION
Fixes #1350

Manually verified that new reports links work as expected. Note that I had to set `REPORT_URL=https://dash-reporting.tofn9kh9mlm7g.us-east-1.cs.amazonlightsail.com
` in my client/.env file.

  - [ ] Up to date with `dev` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
