### PR TITLE
remove fromMonth to nav to previous months on date filter

### DIFF
--- a/client/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/client/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -66,7 +66,6 @@ function ReactDayPicker({
         className="Range"
         disabledDays={{ before: lastThreeMonths, after: today }}
         numberOfMonths={1}
-        fromMonth={from}
         selectedDays={[from, { from, to: enteredToDate }]}
         modifiers={{ start: from, end: enteredToDate }}
         onDayClick={handleDayClick}


### PR DESCRIPTION
Fixes #1360

This was a pretty simple fix--just need to remove `fromMonth`, which is used to [limit](https://react-day-picker.js.org/basics/navigation#between-months-or-dates) month navigation. 

  - [x] Up to date with `dev` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
