### PR TITLE
1383 need to update contentfulcom to mirror the content in figma eg remove the privacy policy heading from the content area

### DIFF
--- a/client/components/main/Privacy.jsx
+++ b/client/components/main/Privacy.jsx
@@ -18,7 +18,7 @@ const query = `
   query {
     simplePageCollection(where: {slug: "privacy"}) {
       items {
-        title
+        slug
         body
       }
     }

--- a/client/components/main/Privacy.jsx
+++ b/client/components/main/Privacy.jsx
@@ -1,26 +1,22 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import sharedLayout from '@theme/layout';
 import TextHeading from '@components/common/TextHeading';
 import ContentBody from '@components/common/ContentBody';
 import useContentful from '../../hooks/useContentful';
 
-const useStyles = makeStyles(theme => ({
-  contentTitle: {
-    fontWeight: theme.typography.fontWeightBold,
+const useStyles = makeStyles({
+  contentBody: {
+    fontSize: '1rem',
   },
-}));
+});
 
 const query = `
   query {
-    simplePageCollection(where: {slug: "privacy"}) {
-      items {
-        slug
-        body
-      }
+      privacyPolicy(id: "2HBnjUBMJ7KNimZGjhAsEi") {
+      body
     }
   }
 `;
@@ -42,13 +38,10 @@ const Privacy = () => {
       <ContentBody maxWidth="md">
         { data
         && (
-          <Grid container className={classes.marginTopSmall}>
+          <Grid container>
             <Grid item>
-              <Typography variant="h6" className={classes.contentTitle}>
-                {data.simplePageCollection.items[0].title}
-              </Typography>
-              <ReactMarkdown>
-                {data.simplePageCollection.items[0].body}
+              <ReactMarkdown className={classes.contentBody}>
+                {data.privacyPolicy.body}
               </ReactMarkdown>
             </Grid>
           </Grid>


### PR DESCRIPTION
Fixes #1383 

  - [] Up to date with `dev` branch
  - [] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Created new Content Model for Privacy. Removed title field. 

<img width="1122" alt="Screen Shot 2023-03-11 at 5 13 02 PM" src="https://user-images.githubusercontent.com/3441200/224518857-ad83b1d6-1562-4cda-b910-4a080e6bbb13.png">
