### PR TITLE
Remove no:project label

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -2,7 +2,7 @@
 name: Blank Issue
 about: Describe this issue's purpose here
 title: ''
-labels: 'Milestone: Missing,Role: Missing,Size: Missing, Feature:Missing,no:project'
+labels: 'Milestone: Missing,Role: Missing,Size: Missing,Feature:Missing'
 assignees: ''
 
 ---


### PR DESCRIPTION
no:project was not an actual label, hence we are removing it.
