### PR TITLE
Fix AcknowledgeModal to only show on initial load

### DIFF
--- a/components/Loading/AcknowledgeModal.jsx
+++ b/components/Loading/AcknowledgeModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   styled, Box, Modal, Typography, Link, Button,
 } from '@mui/material';
@@ -43,10 +44,11 @@ const buttonStyle = {
   fontWeight: '500',
 };
 
-function AcknowledgeModal() {
+function AcknowledgeModal({onClose}) {
   const [open, setOpen] = React.useState(true);
   const handleClose = () => {
     setOpen(false);
+    onClose();
   };
   return (
     <StyledModal open={open}>
@@ -77,3 +79,7 @@ function AcknowledgeModal() {
 }
 
 export default AcknowledgeModal;
+
+AcknowledgeModal.propTypes = {
+  onClose: PropTypes.func.isRequired
+};

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -53,6 +53,7 @@ class MapContainer extends React.Component {
       position: props.position,
       lastUpdated: props.lastUpdated,
       selectedTypes: this.getSelectedTypes(),
+      acknowledgeModalShown: false
     };
 
     // We store the raw requests from the API call here, but eventually they aremap/inde
@@ -369,6 +370,10 @@ class MapContainer extends React.Component {
     return requestTypes;
   };
 
+  onClose = () => {
+    this.state.acknowledgeModalShown = true;
+  }
+
   render() {
     const {
       position,
@@ -380,7 +385,7 @@ class MapContainer extends React.Component {
       isMapLoading,
       isDbLoading,
     } = this.props;
-    const { ncCounts, ccCounts, selectedTypes } = this.state;
+    const { ncCounts, ccCounts, selectedTypes, acknowledgeModalShown } = this.state;
     return (
       <div className={classes.root}>
         <Map
@@ -395,13 +400,13 @@ class MapContainer extends React.Component {
           initialState={this.initialState}
         />
         <CookieNotice />
-        {(isDbLoading || isMapLoading) ? (
+        {(isDbLoading || isMapLoading) && acknowledgeModalShown === false ? (
           <>
             <LoadingModal />
             <FunFactCard />
           </>
         ) : (
-          <AcknowledgeModal/>
+          <AcknowledgeModal onClose={this.onClose}/>
         )}
       </div>
     );

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -400,14 +400,14 @@ class MapContainer extends React.Component {
           initialState={this.initialState}
         />
         <CookieNotice />
-        {(isDbLoading || isMapLoading) && acknowledgeModalShown === false ? (
+        {(isDbLoading || isMapLoading) ? (
           <>
             <LoadingModal />
             <FunFactCard />
           </>
-        ) : (
+        ) : (acknowledgeModalShown === false) ? (
           <AcknowledgeModal onClose={this.onClose}/>
-        )}
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
Fixes #1707

### What changes did you make?
- Add a new state to `MapContainer` to track if the `AcknowledgeModal` has been shown.
- Update the ternary to render the AcknowledgeModal only if the data is done loading.  
- Update `AcknowledgeModal` to accept a callback prop for closing.
 
### Why did you make the changes (we will use this info to test)?
  - To ensured that AcknowledgeModal is displayed only once upon the initial load of the application and does not reappear after subsequent data load or filter updates, so that users can have more smooth interaction with the map.
  - [ ] Up to date with `main` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved
Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
