### PR TITLE
1666 pull data from previous years

### DIFF
--- a/components/Footer/LastUpdated.jsx
+++ b/components/Footer/LastUpdated.jsx
@@ -21,7 +21,7 @@ function LastUpdated() {
 
   useEffect(() => {
     const getLastUpdated = async () => {
-      const getLastUpdatedSQL = 'select max(createddate) from requests;';
+      const getLastUpdatedSQL = 'select max(createddate) from requests_2024;';
 
       const lastUpdatedAsArrowTable = await conn.query(getLastUpdatedSQL);
       const results = ddbh.getTableData(lastUpdatedAsArrowTable);

--- a/components/Map/RequestDetail.jsx
+++ b/components/Map/RequestDetail.jsx
@@ -63,10 +63,10 @@ function RequestDetail({
   // dispatchGetPinInfoRequest,
   dispatchUpdatePinInfo,
 }) {
-  const { conn } = useContext(DbContext);
+  const { conn, tableNameByYear } = useContext(DbContext);
   const getPinInfo = useCallback(async () => {
     try {
-      const getPinsInfoSQL = `SELECT * FROM requests WHERE TRIM(SRNumber) = '${requestId}'`;
+      const getPinsInfoSQL = `SELECT * FROM ${tableNameByYear} WHERE TRIM(SRNumber) = '${requestId}'`;
 
       const pinsInfoAsArrowTable = await conn.query(getPinsInfoSQL);
       const newPinsInfo = ddbh.getTableData(pinsInfoAsArrowTable);

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -309,27 +309,9 @@ class MapContainer extends React.Component {
     return dateArray;
   };
 
-  // getAllRequests = async (startDate, endDate) => {
-  //   try {
-  //     const { conn, tableNameByYear } = this.context;
-
-  //     // Execute a SELECT query from 'requests' table
-  //     const selectSQL = `SELECT * FROM ${tableNameByYear} WHERE CreatedDate between '${startDate}' and '${endDate}'`;
-
-  //     const requestsAsArrowTable = await conn.query(selectSQL);
-
-  //     const requests = ddbh.getTableData(requestsAsArrowTable);
-
-  //     this.endTime = performance.now(); // end bnechmark
-
-  //     console.log(
-  //       `Time taken to bootstrap db: ${Math.floor(this.endTime - this.startTime)} ms`
-  //     );
-  //     return requests;
-  //   } catch (e) {
-  //     console.error(e);
-  //   }
-  // };
+  // To handle cross-year date ranges, we check if the startDate and endDate year are the same year
+  // if same year, we simply query from that year's table
+  // if different years, we query both startDate year and endDate year, then union the result
 
   async getAllRequests(startDate, endDate) {
     const { conn } = this.context;

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -311,7 +311,6 @@ class MapContainer extends React.Component {
   getAllRequests = async (startDate, endDate) => {
     try {
       const { conn, tableNameByYear } = this.context;
-      const year = moment(startDate).year();
 
       // Execute a SELECT query from 'requests' table
       const selectSQL = `SELECT * FROM ${tableNameByYear} WHERE CreatedDate between '${startDate}' and '${endDate}'`;

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -69,7 +69,7 @@ class MapContainer extends React.Component {
 
     // Create the 'requests' table.
     const createSQL =
-      'CREATE TABLE requests AS SELECT * FROM "requests2024.parquet"'; // parquet
+      'CREATE TABLE requests AS SELECT * FROM "requests2024.parquet"'; // query from parquet
 
     await conn.query(createSQL);
   };

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -69,7 +69,7 @@ class MapContainer extends React.Component {
 
     // Create the 'requests' table.
     const createSQL =
-      'CREATE TABLE requests AS SELECT * FROM "requests.parquet"'; // parquet
+      'CREATE TABLE requests AS SELECT * FROM "requests2024.parquet"'; // parquet
 
     await conn.query(createSQL);
   };

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -71,10 +71,11 @@ class MapContainer extends React.Component {
     const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
     const year = moment(startDate).year(); // extrac the year
     const datasetFileName = `requests${year}.parquet`;
-    const tableName = `requests_${year}`;
+    const tableName = `requests_${year}`; // dynamic table name by year extracted from startDate
 
     // Create the year data table.
     const createSQL =
+    // create new table only if year changed
       `CREATE TABLE IF NOT EXISTS ${tableName} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
       try {
         await conn.query(createSQL);
@@ -84,8 +85,6 @@ class MapContainer extends React.Component {
       } finally {
         this.setState({ isTableLoading: false});
       }
-
-    // await conn.query(createSQL);
   };
 
   async componentDidMount(props) {
@@ -97,6 +96,8 @@ class MapContainer extends React.Component {
 
   async componentDidUpdate(prevProps) {
     const { activeMode, pins, startDate, endDate } = this.props;
+
+    // create conditions to check if year or startDate or endDate changed
     const yearChanged = moment(prevProps.startDate).year() !== moment(startDate).year();
     const startDateChanged = prevProps.startDate !== startDate;
     const endDateChanged = prevProps.endDate !== endDate;

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -53,6 +53,7 @@ class MapContainer extends React.Component {
       position: props.position,
       lastUpdated: props.lastUpdated,
       selectedTypes: this.getSelectedTypes(),
+      isTableLoading: false,
     };
 
     // We store the raw requests from the API call here, but eventually they aremap/inde
@@ -65,14 +66,14 @@ class MapContainer extends React.Component {
   }
 
   createRequestsTable = async () => {
+    this.setState({ isTableLoading: true });
     const { conn } = this.context;
-
     const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
     const year = moment(startDate).year(); // extrac the year
     const datasetFileName = `requests${year}.parquet`;
     const tableName = `requests_${year}`;
 
-    // Create the 'requests' table.
+    // Create the year data table.
     const createSQL =
       `CREATE TABLE IF NOT EXISTS ${tableName} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
       try {
@@ -80,6 +81,8 @@ class MapContainer extends React.Component {
         console.log("Table created and dataset registered successfully.");
       } catch (error) {
         console.error("Error in creating table or registering dataset:", error);
+      } finally {
+        this.setState({ isTableLoading: false});
       }
 
     // await conn.query(createSQL);
@@ -394,7 +397,7 @@ class MapContainer extends React.Component {
       isMapLoading,
       isDbLoading,
     } = this.props;
-    const { ncCounts, ccCounts, selectedTypes } = this.state;
+    const { ncCounts, ccCounts, selectedTypes, isTableLoading } = this.state;
     return (
       <div className={classes.root}>
         <Map
@@ -409,7 +412,7 @@ class MapContainer extends React.Component {
           initialState={this.initialState}
         />
         <CookieNotice />
-        {(isDbLoading || isMapLoading) ? (
+        {(isDbLoading || isMapLoading || isTableLoading) ? (
           <>
             <LoadingModal />
             <FunFactCard />

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -82,7 +82,7 @@ class MapContainer extends React.Component {
       try {
         await conn.query(createSQL);
         const endTime = performance.now() // end the timer
-        console.log(`Table created and dataset registered. Time taken: ${Math.floor(endTime - startTime)} ms.`);
+        console.log(`Dataset registration & table creation (by year) time: ${Math.floor(endTime - startTime)} ms.`);
       } catch (error) {
         console.error("Error in creating table or registering dataset:", error);
       } finally {
@@ -339,8 +339,16 @@ class MapContainer extends React.Component {
         `;
       }
 
+      const dataLoadStartTime = performance.now();
       const requestsAsArrowTable = await conn.query(selectSQL);
+      const dataLoadEndTime = performance.now();
+
+      console.log(`Data loading time: ${Math.floor(dataLoadEndTime - dataLoadStartTime)} ms`);
+
       const requests = ddbh.getTableData(requestsAsArrowTable);
+      const mapLoadEndTime = performance.now();
+
+      console.log(`Map loading time: ${Math.floor(mapLoadEndTime - dataLoadEndTime)} ms`);
 
       return requests;
     } catch (e) {

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -67,15 +67,15 @@ class MapContainer extends React.Component {
 
   createRequestsTable = async () => {
     this.setState({ isTableLoading: true });
-    const { conn } = this.context;
+    const { conn, tableNameByYear } = this.context;
     const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
     const year = moment(startDate).year(); // extrac the year
     const datasetFileName = `requests${year}.parquet`;
-    const tableName = `requests_${year}`; // dynamic table name by year extracted from startDate
+    // const tableName = `requests_${year}`; // dynamic table name by year extracted from startDate
 
     // Create the year data table if not exist already
     const createSQL =
-      `CREATE TABLE IF NOT EXISTS ${tableName} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
+      `CREATE TABLE IF NOT EXISTS ${tableNameByYear} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
 
     const startTime = performance.now(); // start the time tracker
 
@@ -311,12 +311,11 @@ class MapContainer extends React.Component {
 
   getAllRequests = async (startDate, endDate) => {
     try {
-      const { conn } = this.context;
+      const { conn, tableNameByYear } = this.context;
       const year = moment(startDate).year();
-      const tableName = `requests_${year}`;
 
       // Execute a SELECT query from 'requests' table
-      const selectSQL = `SELECT * FROM ${tableName} WHERE CreatedDate between '${startDate}' and '${endDate}'`;
+      const selectSQL = `SELECT * FROM ${tableNameByYear} WHERE CreatedDate between '${startDate}' and '${endDate}'`;
 
       const requestsAsArrowTable = await conn.query(selectSQL);
 

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -73,13 +73,16 @@ class MapContainer extends React.Component {
     const datasetFileName = `requests${year}.parquet`;
     const tableName = `requests_${year}`; // dynamic table name by year extracted from startDate
 
-    // Create the year data table.
+    // Create the year data table if not exist already
     const createSQL =
-    // create new table only if year changed
       `CREATE TABLE IF NOT EXISTS ${tableName} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
+
+    const startTime = performance.now(); // start the time tracker
+
       try {
         await conn.query(createSQL);
-        console.log("Table created and dataset registered successfully.");
+        const endTime = performance.now() // end the timer
+        console.log(`Table created and dataset registered. Time taken: ${Math.floor(endTime - startTime)} ms.`);
       } catch (error) {
         console.error("Error in creating table or registering dataset:", error);
       } finally {
@@ -322,7 +325,7 @@ class MapContainer extends React.Component {
       this.endTime = performance.now(); // end bnechmark
 
       console.log(
-        `Time taken to bootstrap db: ${this.endTime - this.startTime}ms`
+        `Time taken to bootstrap db: ${Math.floor(this.endTime - this.startTime)} ms`
       );
       return requests;
     } catch (e) {

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -66,10 +66,15 @@ class MapContainer extends React.Component {
 
   createRequestsTable = async () => {
     const { conn } = this.context;
+    const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
+    const year = moment(startDate).year(); // extrac the year
+
+    const datasetYear = year === 2024 ? '2024' : '2023';
+    const datasetFileName = `requests${datasetYear}.parquet`
 
     // Create the 'requests' table.
     const createSQL =
-      'CREATE TABLE requests AS SELECT * FROM "requests2024.parquet"'; // query from parquet
+      `CREATE TABLE requests AS SELECT * FROM "${datasetFileName}"`; // query from parquet
 
     await conn.query(createSQL);
   };
@@ -443,6 +448,7 @@ MapContainer.propTypes = {};
 
 MapContainer.defaultProps = {};
 
+// connect MapContainer to Redux store
 export default connect(
   mapStateToProps,
   mapDispatchToProps

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -71,7 +71,6 @@ class MapContainer extends React.Component {
     const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
     const year = moment(startDate).year(); // extrac the year
     const datasetFileName = `requests${year}.parquet`;
-    // const tableName = `requests_${year}`; // dynamic table name by year extracted from startDate
 
     // Create the year data table if not exist already
     const createSQL =

--- a/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -222,7 +222,7 @@ function ReactDayPicker({
         onDayClick={handleDayClick}
         onDayMouseEnter={handleDayMouseEnter}
         weekdayElement={<WeekDay />}
-        fromMonth={new Date(2023, 12)}
+        fromMonth={new Date(2022, 12)}
       />
     </>
   );

--- a/components/db/DbContext.jsx
+++ b/components/db/DbContext.jsx
@@ -4,7 +4,7 @@ const DbContext = React.createContext({
   db: null,
   conn: null,
   worker: null,
-  tableName: '',
+  tableNameByYear: '',
 });
 
 export default DbContext;

--- a/components/db/DbContext.jsx
+++ b/components/db/DbContext.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
 
-const DbContext = React.createContext();
+const DbContext = React.createContext({
+  db: null,
+  conn: null,
+  worker: null,
+  tableName: '',
+});
 
 export default DbContext;

--- a/components/db/DbProvider.jsx
+++ b/components/db/DbProvider.jsx
@@ -142,7 +142,7 @@ DbProvider.propTypes = {
 
 DbProvider.defaultProps = {
   children: null,
-  startDate: PropTypes.string,
+  startDate: null,
 };
 
 // connect DbProvider to Redux to get startDate

--- a/components/db/DbProvider.jsx
+++ b/components/db/DbProvider.jsx
@@ -8,8 +8,10 @@ import DbContext from '@db/DbContext';
 const datasets = {
   parquet: {
     // huggingface
-    hfYtd:
-      'https://huggingface.co/datasets/311-data/2024/resolve/main/2024.parquet', // year-to-date
+    hfYtd2024:
+      'https://huggingface.co/datasets/311-data/2024/resolve/main/2024.parquet', // 2024 year-to-date
+    hfYtd2023:
+      'https://huggingface.co/datasets/311-data/2023/resolve/main/2023.parquet', // 2023 year-to-date
     hfLastMonth:
       'https://huggingface.co/datasets/edwinjue/311-data-last-month/resolve/refs%2Fconvert%2Fparquet/edwinjue--311-data-last-month/csv-train.parquet', // last month
   },
@@ -49,14 +51,20 @@ function DbProvider({ children }) {
 
         await newDb.instantiate(
           DUCKDB_CONFIG.mainModule,
-          DUCKDB_CONFIG.pthreadWorker
+          DUCKDB_CONFIG.pthreadWorker,
         );
 
         // register parquet
         await newDb.registerFileURL(
-          'requests.parquet',
-          datasets.parquet.hfYtd,
-          4 // HTTP = 4. For more options: https://tinyurl.com/DuckDBDataProtocol
+          'requests2024.parquet',
+          datasets.parquet.hfYtd2024,
+          4, // HTTP = 4. For more options: https://tinyurl.com/DuckDBDataProtocol
+        );
+
+        await newDb.registerFileURL(
+          'requests2023.parquet',
+          datasets.parquet.hfYtd2023,
+          4,
         );
 
         // Create db connection


### PR DESCRIPTION
Fixes #1666 

### Pre-Merge Checklist

  - [x] Up to date with `main` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved

### Changes Made

- Transfer the 2023 parquet file from old HuggingFace (Edwin's personal) to 311 Data's HuggingFace 2023 repo
- Set up dataset parquet file URL pointers and file path registrations in `DbProvider`
- Re-enable UI calendar to browse back to 2023 in `ReactDayPicker`
- Extract current calendar date year from Redux `startDate` prop, use it to dynamically query parquet file name by year as well as create db table by year
- Uplift dynamic table name generation logic to `DbProvider` as a DbContext prop, so that it can be access both in `MapContainer` and `RequestDetail` and also accessible anywhere that requires this table name in the codebase.

### Bug Fixed at Testing
- Bug Fix: Update the query table name to current year in the Footer's `LastUpdated` component, kept it static for now
- Bug Fix: Update the query table name to the dynamic table name context prop in `RequestDetail`
- Bug Fix: Added `isTableLoading` flag to the conditional rendering loading modals to cover the tabble creation time

### More Info

2023 data is now available for browsing on the UI in this PR. This ticket was a prototype to see if our solution would work. Now that it works, Ryan will create a new ticket to apply the same data flow for the rest of the previous years, ie. 2016 to 2022.
