### PR TITLE
consolidate tooltip code to ArrowToolTip and use it for info popovers

### DIFF
--- a/components/DateSelector/DateSelector.jsx
+++ b/components/DateSelector/DateSelector.jsx
@@ -48,7 +48,7 @@ function DateSelector({
             <p className={tooltipParagraph}>
               <strong>
                 Currently, 311-Data loads only 311 service
-                request data from 2024 onward.
+                request data from 2023 onward.
               </strong>
             </p>
             <p className={tooltipParagraph}>

--- a/components/DateSelector/DateSelector.jsx
+++ b/components/DateSelector/DateSelector.jsx
@@ -8,9 +8,7 @@ import {
   updateStartDate as reduxUpdateStartDate,
   updateEndDate as reduxUpdateEndDate,
 } from '@reducers/filters';
-import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { styled } from '@mui/material/styles';
+import ArrowToolTip from '@components/common/ArrowToolTip';
 import options from './options';
 import useStyles from './useStyles';
 import DateRanges from './DateRanges';
@@ -37,59 +35,28 @@ function DateSelector({
     setExpanded(false);
   }, []);
 
-  const { option, selected } = classes;
+  const { option, selected, label, iconStyle, tooltipParagraph } = classes;
 
-  const ArrowToolTip = styled(({ className }) => (
-    <Tooltip
-      placement="top-end"
-      arrow
-      classes={{ popper: className }}
-      title={
-        (
+  const linkedinPageLink = <a href='https://www.linkedin.com/company/hack-for-la/'>LinkedIn Page</a>
+
+  return (
+    <>
+      <span className={label}>
+        Date Range&nbsp;
+        <ArrowToolTip iconStyle={iconStyle}>
           <div>
-            <p className={classes.tooltipParagraph}>
+            <p className={tooltipParagraph}>
               <strong>
                 Currently, 311-Data loads only 311 service
                 request data from 2024 onward.
               </strong>
             </p>
-            <p className={classes.tooltipParagraph}>
+            <p className={tooltipParagraph}>
               For updates on the release of available 311
-              Data, please follow our
-              {` `}
-              <a href='https://www.linkedin.com/company/hack-for-la/'>
-                LinkedIn Page
-              </a>
-            .
+              Data, please follow our {linkedinPageLink}.
             </p>
           </div>
-        )
-      }
-    >
-      <InfoOutlinedIcon
-        className={classes.iconStyle}
-        fontSize="inherit"
-      />
-    </Tooltip>
-  ))(({ theme }) => ({
-    [`& .${tooltipClasses.arrow}`]: {
-      '&::before': {
-        backgroundColor: theme.palette.common.white,
-      },
-    },
-    [`& .${tooltipClasses.tooltip}`]: {
-      backgroundColor: theme.palette.common.white,
-      color: theme.palette.common.black,
-      marginLeft: '-4px',
-      maxWidth: '275px',
-      padding: '5px',
-    },
-  }));
-  return (
-    <>
-      <span className={classes.label}>
-        Date Range&nbsp;
-        <ArrowToolTip />
+        </ArrowToolTip>
       </span>
       <SelectorBox onToggle={() => setExpanded(!expanded)} expanded={expanded}>
         <SelectorBox.Display>

--- a/components/common/ArrowToolTip/index.jsx
+++ b/components/common/ArrowToolTip/index.jsx
@@ -1,0 +1,47 @@
+import { styled } from '@mui/material/styles';
+import PropTypes from 'prop-types';
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import React from 'react';
+
+const ArrowToolTip = ({iconStyle, children}) => {
+
+  const StyledToolTip = styled(({ className }) => (
+    <Tooltip
+      placement="top-end"
+      arrow
+      classes={{ popper: className }}
+      title={(children)}
+    >
+      <InfoOutlinedIcon
+        className={iconStyle}
+        fontSize="inherit"
+      />
+    </Tooltip>
+  ))(({ theme }) => ({
+    [`& .${tooltipClasses.arrow}`]: {
+      '&::before': {
+        backgroundColor: theme.palette.common.white,
+      },
+    },
+    [`& .${tooltipClasses.tooltip}`]: {
+      backgroundColor: theme.palette.common.white,
+      color: theme.palette.common.black,
+      marginLeft: '-4px',
+      maxWidth: '275px',
+      padding: '5px',
+      boxShadow: `
+        0 4px 4px 0 rgba(0, 0, 0, 0.25), 
+        0 8px 10px 0 rgba(0, 0, 0, 0.14), 
+        0 3px 14px 0 rgba(0, 0, 0, 0.12)
+      `,
+    },
+  }));
+
+  return <StyledToolTip/>;
+};
+
+export default ArrowToolTip;
+ArrowToolTip.propTypes = {
+  children: PropTypes.node.isRequired,
+}

--- a/components/common/ArrowToolTip/index.jsx
+++ b/components/common/ArrowToolTip/index.jsx
@@ -44,4 +44,5 @@ const ArrowToolTip = ({iconStyle, children}) => {
 export default ArrowToolTip;
 ArrowToolTip.propTypes = {
   children: PropTypes.node.isRequired,
+  iconStyles: PropTypes.string,
 }

--- a/components/main/Desktop/StatusSelector.jsx
+++ b/components/main/Desktop/StatusSelector.jsx
@@ -6,6 +6,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { updateRequestStatus } from '@reducers/filters';
+import ArrowToolTip from '@components/common/ArrowToolTip';
 
 const useStyles = makeStyles(() => ({
   header: {
@@ -18,6 +19,9 @@ const useStyles = makeStyles(() => ({
   },
   button: {
     width: '50%',
+  },
+  tooltipParagraph: {
+    margin: '1px',
   },
 }));
 
@@ -34,7 +38,17 @@ function StatusSelector({
 
   return (
     <>
-      <div className={classes.header}>Request Status</div>
+      <div className={classes.header}>
+        Request Status&nbsp;
+        <ArrowToolTip iconStyle={classes.iconStyle}>
+          <p className={classes.tooltipParagraph}>
+            There are multiple definitions of closed, including the following:
+            The issue may have already been reported (duplicate request),
+            the issue could have been resolved, or a service technician visited
+            the site of the reported issue and put in an internal request to resolve it.
+          </p>
+        </ArrowToolTip>
+      </div>
       <ToggleButtonGroup
         value={selection}
         onChange={handleSelection}

--- a/components/main/Desktop/TypeSelector/index.js
+++ b/components/main/Desktop/TypeSelector/index.js
@@ -13,6 +13,7 @@ import { updateRequestTypes } from '@reducers/filters';
 // import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import sharedLayout from '@theme/layout';
 import useToggle from './isToggle';
+import ArrowToolTip from '@components/common/ArrowToolTip';
 
 const useStyles = makeStyles(theme => ({
   iconStyle: {
@@ -21,6 +22,9 @@ const useStyles = makeStyles(theme => ({
   header: {
     fontSize: '12.47px',
     fontWeight: theme.typography.fontWeightMedium,
+  },
+  tooltipParagraph: {
+    margin: '1px',
   },
 }));
 
@@ -71,14 +75,20 @@ function RequestTypeSelector({
     });
   }
 
+  const myla311Link = <a href="https://www.myla311.lacity.org">MyLa311</a>;
+
   return (
     <Grid container direction="column">
       <Grid item>
         <Typography variant="body2" className={classes.header}>
           Request&nbsp;Types&nbsp;
-          <Tooltip title="Info">
-            <InfoOutlinedIcon className={classes.iconStyle} fontSize="inherit" />
-          </Tooltip>
+          <ArrowToolTip iconStyle={classes.iconStyle}>
+            <p className={classes.tooltipParagraph}>
+              The service request categories for this public dataset are maintained by
+              Information Technologies Agency and may not reflect the categories
+              available on {myla311Link}.
+            </p>
+          </ArrowToolTip>
         </Typography>
       </Grid>
       <Grid item className={classes.marginTopSmall}>


### PR DESCRIPTION
Fixes #1724 and #1718

  - [x] Up to date with `main` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

### Changes
- Created ArrowToolTip component to hold the common MUI components and styles for this tooltip
  - relies on `props.children` to specify the children for this component
  - also relies on `props.iconStyle`, but potentially could generate this within the component (rather than as a prop)
- Utilize ArrowToolTip for the following Search and Filters modal
  - Request Dates
  - Request Types
  - Request Status 

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
