### PR TITLE
Add console logs for pin loads 1719

### DIFF
--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -178,9 +178,9 @@ class Map extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     const entireMapLoadTime = () => {
       if (this.map.isSourceLoaded('requests')) {
-        const { startTime } = this.context;
-        const endTime = performance.now()
-        console.log(`Pin load time: ${Math.floor(endTime - startTime)} ms`)
+        const { dbStartTime } = this.context;
+        const pinLoadEndTime = performance.now()
+        console.log(`Pin load time: ${Math.floor(pinLoadEndTime - dbStartTime)} ms`)
         this.map.off('idle', entireMapLoadTime);
       }
     }

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -68,7 +68,7 @@ class MapContainer extends React.Component {
 
   createRequestsTable = async () => {
     this.setState({ isTableLoading: true });
-    const { conn, tableNameByYear } = this.context;
+    const { conn, tableNameByYear, setStartTime } = this.context;
     const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
     const year = moment(startDate).year(); // extrac the year
     const datasetFileName = `requests${year}.parquet`;
@@ -78,6 +78,8 @@ class MapContainer extends React.Component {
       `CREATE TABLE IF NOT EXISTS ${tableNameByYear} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
 
     const startTime = performance.now(); // start the time tracker
+    console.log('startTime in map/index.js', startTime)
+    setStartTime(startTime)
 
       try {
         await conn.query(createSQL);
@@ -99,7 +101,6 @@ class MapContainer extends React.Component {
 
   async componentDidUpdate(prevProps) {
     const { activeMode, pins, startDate, endDate } = this.props;
-
     // create conditions to check if year or startDate or endDate changed
     const yearChanged = moment(prevProps.startDate).year() !== moment(startDate).year();
     const startDateChanged = prevProps.startDate !== startDate;

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -78,7 +78,6 @@ class MapContainer extends React.Component {
       `CREATE TABLE IF NOT EXISTS ${tableNameByYear} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
 
     const startTime = performance.now(); // start the time tracker
-    console.log('startTime in map/index.js', startTime)
     setStartTime(startTime)
 
       try {

--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -68,7 +68,7 @@ class MapContainer extends React.Component {
 
   createRequestsTable = async () => {
     this.setState({ isTableLoading: true });
-    const { conn, tableNameByYear, setStartTime } = this.context;
+    const { conn, tableNameByYear, setDbStartTime } = this.context;
     const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
     const year = moment(startDate).year(); // extrac the year
     const datasetFileName = `requests${year}.parquet`;
@@ -78,7 +78,7 @@ class MapContainer extends React.Component {
       `CREATE TABLE IF NOT EXISTS ${tableNameByYear} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
 
     const startTime = performance.now(); // start the time tracker
-    setStartTime(startTime)
+    setDbStartTime(startTime)
 
       try {
         await conn.query(createSQL);

--- a/components/db/DbContext.jsx
+++ b/components/db/DbContext.jsx
@@ -5,6 +5,7 @@ const DbContext = React.createContext({
   conn: null,
   worker: null,
   tableNameByYear: '',
+  startTime: null,
 });
 
 export default DbContext;

--- a/components/db/DbProvider.jsx
+++ b/components/db/DbProvider.jsx
@@ -29,6 +29,7 @@ function DbProvider({ children, startDate }) {
   const [conn, setConn] = useState(null);
   const [worker, setWorker] = useState(null);
   const [tableNameByYear, setTableNameByYear] = useState('');
+  const [startTime, setStartTime] = useState(null);
 
   useEffect(() => {
     const dbInitialize = async () => {
@@ -127,7 +128,12 @@ function DbProvider({ children, startDate }) {
 
   return (
     <DbContext.Provider value={{
-      db, conn, worker, tableNameByYear,
+      db,
+      conn,
+      worker,
+      tableNameByYear,
+      startTime,
+      setStartTime,
     }}
     >
       {children}

--- a/components/db/DbProvider.jsx
+++ b/components/db/DbProvider.jsx
@@ -29,7 +29,7 @@ function DbProvider({ children, startDate }) {
   const [conn, setConn] = useState(null);
   const [worker, setWorker] = useState(null);
   const [tableNameByYear, setTableNameByYear] = useState('');
-  const [startTime, setStartTime] = useState(null);
+  const [dbStartTime, setDbStartTime] = useState(null);
 
   useEffect(() => {
     const dbInitialize = async () => {
@@ -132,8 +132,8 @@ function DbProvider({ children, startDate }) {
       conn,
       worker,
       tableNameByYear,
-      startTime,
-      setStartTime,
+      dbStartTime,
+      setDbStartTime,
     }}
     >
       {children}


### PR DESCRIPTION
Fixes  #1719

  - [X] Up to date with `main` branch
  - [X] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [X] All PR Status checks are successful
  - [ ] Peer reviewed and approved

1.  Start time is defined when a query is made to the database
2.  End time is defined when the map is finished loading
3.  Test case: Although this is not extremely accurate,  I started a stopwatch when I selected a new date range if it is going back previous years. This is done because a new SQL query is needed if going back previous years.  It seems to be fairly close, but may take 1-2 seconds more after pins have fully loaded. 

### Changes
- Added the pin loading time in the console.log
<img width="549" alt="Screenshot 2024-05-22 at 3 56 48 PM" src="https://github.com/hackforla/311-data/assets/83096266/a599793b-6c9d-4bf5-bae8-f52cd03ff26b">
