### PR TITLE
1740 make loading modal only appear on the map page

### DIFF
--- a/components/Map/index.js
+++ b/components/Map/index.js
@@ -444,14 +444,18 @@ class MapContainer extends React.Component {
           initialState={this.initialState}
         />
         <CookieNotice />
-        {(isDbLoading || isMapLoading || isTableLoading) ? (
-          <>
-            <LoadingModal />
-            <FunFactCard />
-          </>
-        ) : (acknowledgeModalShown === false) ? (
-          <AcknowledgeModal onClose={this.onClose}/>
-        ) : null}
+        {
+          window.location.hash == '#/map' && (
+            (isDbLoading || isMapLoading || isTableLoading) ? (
+              <>
+                <LoadingModal />
+                <FunFactCard />
+              </>
+            ) : (acknowledgeModalShown === false) ? (
+              <AcknowledgeModal onClose={this.onClose}/>
+            ) : null
+          )
+        }
       </div>
     );
   }


### PR DESCRIPTION
Fixes #1740 

  - [X] Up to date with `main` branch
  - [X] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [X] All PR Status checks are successful
  - [x] Peer reviewed and approved

Note: This was tested on Mac OS.  I don't have the resources to test it on Windows. 

Changes

> Page only renders on maps page.  