### PR TITLE
1746 Add SR CSV download for Address and Count

### DIFF
--- a/components/main/Desktop/ExportButton.jsx
+++ b/components/main/Desktop/ExportButton.jsx
@@ -45,9 +45,9 @@ function ExportButton({ filters }) {
     }
 
     const formattedRequestTypes = requestTypes
-      .filter(item => filters.requestTypes[item.typeId])
-      .map(v => `'${v.typeName}'`)
-      .join(', ');
+    .filter(item => filters.requestTypes[item.typeId])
+    .map(reqType => `'${reqType.socrataNames[0]}'`)
+    .join(', ');
 
     const startYear = moment(filters.startDate).year();
     const endYear = moment(filters.endDate).year();
@@ -55,18 +55,19 @@ function ExportButton({ filters }) {
     const getAllRequests = (year, startDate, endDate, councilId = '', status = '') => `
       SELECT * FROM requests_${year} 
       WHERE CreatedDate >= '${startDate}' 
-      AND CreatedDate < '${endDate}'
-      ${status !== '' ? ` AND Status='${status}'` : ''}
+      AND CreatedDate <= '${endDate}'
+      ${status === 'Open' ? " AND (Status = 'Open' OR Status = 'Pending')" : ''}
+      ${status === 'Closed' ? " AND (Status = 'Closed')" : ''}
       ${councilId !== null ? ` AND NC='${councilId}'` : ''} 
       AND RequestType IN (${formattedRequestTypes})`;
 
     // Note: this logic will only generate the SR count CSV if it meets the following conditions:
-    // exactly one SR type is selected, a NC is selected, and status is Open.
+    // exactly one SR type is selected, a NC is selected, and status is Open or Pending.
     const groupRequestsByAddress = (year, startDate, endDate, councilId) => `
       SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${year}
       WHERE CreatedDate >= '${startDate}' 
-      AND CreatedDate < '${endDate}' 
-      AND Status = 'Open' 
+      AND CreatedDate <= '${endDate}' 
+      AND (Status = 'Open' OR Status = 'Pending')
       AND NC = '${councilId}' 
       AND RequestType IN (${formattedRequestTypes})
       GROUP BY Address`;

--- a/components/main/Desktop/ExportButton.jsx
+++ b/components/main/Desktop/ExportButton.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import Button from '@mui/material/Button';
 import PropTypes from 'proptypes';
 import { connect } from 'react-redux';
+import moment from 'moment';
 import JSZip from 'jszip';
 import Papa from 'papaparse';
 import { saveAs } from 'file-saver';
@@ -15,9 +16,14 @@ function ExportButton({ filters }) {
   const { conn } = useContext(DbContext);
 
   // creation zip file
-  const downloadZip = async csvContent => {
+  const downloadZip = async (neighborhoodCsvContent, srCsvContent) => {
     const zip = new JSZip();
-    zip.file('NeighborhoodData.csv', csvContent);
+    zip.file('NeighborhoodData.csv', neighborhoodCsvContent);
+
+    // Only add SR count csv if it was generated
+    if (srCsvContent) {
+      zip.file('ServiceRequestCount.csv', srCsvContent);
+    }
 
     const content = await zip.generateAsync({ type: 'blob' });
     saveAs(content, '311Data.zip');
@@ -43,20 +49,86 @@ function ExportButton({ filters }) {
       .map(v => `'${v.typeName}'`)
       .join(', ');
 
-    // // in the case user chooses one neighborhood or all are selected + dates and status
-    const query = `select * from requests where CreatedDate >= '${filters.startDate}' AND
-    CreatedDate < '${filters.endDate}'${requestStatusFilter !== ''
-      ? ` AND Status='${requestStatusFilter}'` : ''}
-    ${filters.councilId !== null
-        ? ` AND NC='${filters.councilId}'` : ''} AND RequestType IN (${formattedRequestTypes});`;
+    const startYear = moment(filters.startDate).year();
+    const endYear = moment(filters.endDate).year();
 
-    const dataToExport = await conn.query(query);
-    const results = ddbh.getTableData(dataToExport);
+    const generateQuery = (grouped = false) => {
+      if (startYear === endYear) {
+        if (grouped) {
+          return `SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${startYear}
+            WHERE CreatedDate >= '${filters.startDate}' 
+            AND CreatedDate < '${filters.endDate}' 
+            AND Status = 'Open' 
+            AND NC = '${filters.councilId}' 
+            AND RequestType IN (${formattedRequestTypes})
+            GROUP BY Address`;
+        }
+        return `SELECT * FROM requests_${startYear} 
+          WHERE CreatedDate >= '${filters.startDate}' 
+          AND CreatedDate < '${filters.endDate}'
+          ${requestStatusFilter !== '' ? ` AND Status='${requestStatusFilter}'` : ''}
+          ${filters.councilId !== null ? ` AND NC='${filters.councilId}'` : ''} 
+          AND RequestType IN (${formattedRequestTypes});`;
+      }
 
-    if (!isEmpty(results)) {
-      // results chosen to csv
-      const csvContent = Papa.unparse(results);
-      downloadZip(csvContent);
+      const endOfStartYear = moment(filters.startDate).endOf('year').format('YYYY-MM-DD');
+      const startOfEndYear = moment(filters.endDate).startOf('year').format('YYYY-MM-DD');
+
+      if (grouped) {
+        return `(SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${startYear}
+          WHERE CreatedDate BETWEEN '${filters.startDate}' AND '${endOfStartYear}' 
+          AND Status = 'Open' 
+          AND NC = '${filters.councilId}' 
+          AND RequestType IN (${formattedRequestTypes})
+          GROUP BY Address)
+          UNION ALL
+          (SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${endYear}
+          WHERE CreatedDate BETWEEN '${startOfEndYear}' AND '${filters.endDate}' 
+          AND Status = 'Open' 
+          AND NC = '${filters.councilId}' 
+          AND RequestType IN (${formattedRequestTypes})
+          GROUP BY Address)`;
+      }
+      return `(SELECT * FROM requests_${startYear} 
+        WHERE CreatedDate BETWEEN '${filters.startDate}' AND '${endOfStartYear}'
+        ${requestStatusFilter !== '' ? ` AND Status='${requestStatusFilter}'` : ''}
+        ${filters.councilId !== null ? ` AND NC='${filters.councilId}'` : ''} 
+        AND RequestType IN (${formattedRequestTypes}))
+        UNION ALL
+        (SELECT * FROM requests_${endYear} 
+        WHERE CreatedDate BETWEEN '${startOfEndYear}' AND '${filters.endDate}'
+        ${requestStatusFilter !== '' ? ` AND Status='${requestStatusFilter}'` : ''}
+        ${filters.councilId !== null ? ` AND NC='${filters.councilId}'` : ''} 
+        AND RequestType IN (${formattedRequestTypes}))`;
+    };
+
+    const neighborhoodDataQuery = generateQuery();
+    const neighborhoodDataToExport = await conn.query(neighborhoodDataQuery);
+    const neighborhoodResults = ddbh.getTableData(neighborhoodDataToExport);
+
+    if (!isEmpty(neighborhoodResults)) {
+      const neighborhoodCsvContent = Papa.unparse(neighborhoodResults);
+      let groupedAddressesToExport;
+      let srCountResults;
+      let srCsvContent;
+
+      const srTypeCount = Object.values(filters.requestTypes).reduce(
+        (acc, cur) => (cur === true ? acc + 1 : acc),
+        0,
+      );
+
+      // SR count csv data only generated if:
+      // exactly one SR type is selected, NC selected, and status is open
+      if (srTypeCount === 1 && filters.councilId && requestStatusFilter === 'Open') {
+        const groupedAddressQuery = generateQuery(true);
+        groupedAddressesToExport = await conn.query(groupedAddressQuery);
+        srCountResults = ddbh.getTableData(groupedAddressesToExport);
+
+        if (!isEmpty(srCountResults)) {
+          srCsvContent = Papa.unparse(srCountResults);
+        }
+      }
+      downloadZip(neighborhoodCsvContent, srCsvContent);
     } else {
       window.alert('No 311 data available within the selected filters. Please adjust your filters and try again.');
     }

--- a/components/main/Desktop/ExportButton.jsx
+++ b/components/main/Desktop/ExportButton.jsx
@@ -52,62 +52,93 @@ function ExportButton({ filters }) {
     const startYear = moment(filters.startDate).year();
     const endYear = moment(filters.endDate).year();
 
+    const getAllRequests = (year, startDate, endDate, councilId = '', status = '') => `
+      SELECT * FROM requests_${year} 
+      WHERE CreatedDate >= '${startDate}' 
+      AND CreatedDate < '${endDate}'
+      ${status !== '' ? ` AND Status='${status}'` : ''}
+      ${councilId !== null ? ` AND NC='${councilId}'` : ''} 
+      AND RequestType IN (${formattedRequestTypes})`;
+
+    // Note: this logic will only generate the SR count CSV if it meets the following conditions:
+    // exactly one SR type is selected, a NC is selected, and status is Open.
+    const groupRequestsByAddress = (year, startDate, endDate, councilId) => `
+      SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${year}
+      WHERE CreatedDate >= '${startDate}' 
+      AND CreatedDate < '${endDate}' 
+      AND Status = 'Open' 
+      AND NC = '${councilId}' 
+      AND RequestType IN (${formattedRequestTypes})
+      GROUP BY Address`;
+
     const generateQuery = (grouped = false) => {
       if (startYear === endYear) {
         if (grouped) {
-          return `SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${startYear}
-            WHERE CreatedDate >= '${filters.startDate}' 
-            AND CreatedDate < '${filters.endDate}' 
-            AND Status = 'Open' 
-            AND NC = '${filters.councilId}' 
-            AND RequestType IN (${formattedRequestTypes})
-            GROUP BY Address`;
+          // SRs grouped by address from same year
+          return groupRequestsByAddress(
+            startYear,
+            filters.startDate,
+            filters.endDate,
+            filters.councilId,
+          );
         }
-        return `SELECT * FROM requests_${startYear} 
-          WHERE CreatedDate >= '${filters.startDate}' 
-          AND CreatedDate < '${filters.endDate}'
-          ${requestStatusFilter !== '' ? ` AND Status='${requestStatusFilter}'` : ''}
-          ${filters.councilId !== null ? ` AND NC='${filters.councilId}'` : ''} 
-          AND RequestType IN (${formattedRequestTypes});`;
+        // data comes from same year and includes all columns matching filters
+        return getAllRequests(
+          startYear,
+          filters.startDate,
+          filters.endDate,
+          filters.councilId,
+          requestStatusFilter,
+        );
       }
 
       const endOfStartYear = moment(filters.startDate).endOf('year').format('YYYY-MM-DD');
       const startOfEndYear = moment(filters.endDate).startOf('year').format('YYYY-MM-DD');
 
+      // SRs grouped by address with different start and end years
       if (grouped) {
-        return `(SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${startYear}
-          WHERE CreatedDate BETWEEN '${filters.startDate}' AND '${endOfStartYear}' 
-          AND Status = 'Open' 
-          AND NC = '${filters.councilId}' 
-          AND RequestType IN (${formattedRequestTypes})
-          GROUP BY Address)
-          UNION ALL
-          (SELECT Address, COUNT(*) AS NumberOfRequests FROM requests_${endYear}
-          WHERE CreatedDate BETWEEN '${startOfEndYear}' AND '${filters.endDate}' 
-          AND Status = 'Open' 
-          AND NC = '${filters.councilId}' 
-          AND RequestType IN (${formattedRequestTypes})
-          GROUP BY Address)`;
+        return `(${groupRequestsByAddress(
+          startYear,
+          filters.startDate,
+          endOfStartYear,
+          filters.councilId,
+        )}) UNION ALL (${groupRequestsByAddress(
+          endYear,
+          startOfEndYear,
+          filters.endDate,
+          filters.councilId,
+        )})`;
       }
-      return `(SELECT * FROM requests_${startYear} 
-        WHERE CreatedDate BETWEEN '${filters.startDate}' AND '${endOfStartYear}'
-        ${requestStatusFilter !== '' ? ` AND Status='${requestStatusFilter}'` : ''}
-        ${filters.councilId !== null ? ` AND NC='${filters.councilId}'` : ''} 
-        AND RequestType IN (${formattedRequestTypes}))
-        UNION ALL
-        (SELECT * FROM requests_${endYear} 
-        WHERE CreatedDate BETWEEN '${startOfEndYear}' AND '${filters.endDate}'
-        ${requestStatusFilter !== '' ? ` AND Status='${requestStatusFilter}'` : ''}
-        ${filters.councilId !== null ? ` AND NC='${filters.councilId}'` : ''} 
-        AND RequestType IN (${formattedRequestTypes}))`;
+
+      // data with different start and end years and includes all columns matching filters
+      return `(${getAllRequests(
+        startYear,
+        filters.startDate,
+        endOfStartYear,
+        filters.councilId,
+        requestStatusFilter,
+      )}) UNION ALL (${getAllRequests(
+        endYear,
+        startOfEndYear,
+        filters.endDate,
+        filters.councilId,
+        requestStatusFilter,
+      )})`;
     };
 
     const neighborhoodDataQuery = generateQuery();
     const neighborhoodDataToExport = await conn.query(neighborhoodDataQuery);
     const neighborhoodResults = ddbh.getTableData(neighborhoodDataToExport);
+    const formattedResults = neighborhoodResults.map(row => ({
+      ...row,
+      CreatedDate: row.CreatedDate ? moment(row.CreatedDate).format('YYYY-MM-DD HH:mm:ss') : null,
+      UpdatedDate: row.UpdatedDate ? moment(row.UpdatedDate).format('YYYY-MM-DD HH:mm:ss') : null,
+      ServiceDate: row.ServiceDate ? moment(row.ServiceDate).format('YYYY-MM-DD HH:mm:ss') : null,
+      ClosedDate: row.ClosedDate ? moment(row.ClosedDate).format('YYYY-MM-DD HH:mm:ss') : null,
+    }));
 
-    if (!isEmpty(neighborhoodResults)) {
-      const neighborhoodCsvContent = Papa.unparse(neighborhoodResults);
+    if (!isEmpty(formattedResults)) {
+      const neighborhoodCsvContent = Papa.unparse(formattedResults);
       let groupedAddressesToExport;
       let srCountResults;
       let srCsvContent;


### PR DESCRIPTION
Fixes #1746 

### Notes:
- I had to change the table from requests to requests_2024 for the queries to work. Should this be left as requests or requests_2024 for now?
- This implementation will only generate the SR count CSV if it meets the following conditions: exactly one SR type is selected, a NC is selected, and status is Open. Should any of those requirements be changed?
- I've verified that the CSV is generated in the specified conditions, along with NeighborhoodData.csv that was previously implemented

  - [ ] Up to date with `main` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
