### PR TITLE
fix: restore logo to footer

### DIFF
--- a/components/Footer/LastUpdated.jsx
+++ b/components/Footer/LastUpdated.jsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
 import DbContext from '@db/DbContext';
 import ddbh from '@utils/duckDbHelpers.js';
-import { isEmpty } from '@utils';
+import { isEmpty, toNonBreakingSpaces } from '@utils';
 
 const useStyles = makeStyles(theme => ({
   lastUpdated: {
@@ -39,8 +39,9 @@ function LastUpdated() {
     lastUpdated && (
       <div>
         <Typography variant="body2" className={classes.lastUpdated}>
-          Data&nbsp;last&nbsp;updated&nbsp;
-          {moment(lastUpdated).format('MM/DD/YY')}
+          {toNonBreakingSpaces(
+            `Data last updated ${moment(lastUpdated).format('MM/DD/YY')}`
+          )}
         </Typography>
       </div>
     )

--- a/components/Footer/LastUpdated.jsx
+++ b/components/Footer/LastUpdated.jsx
@@ -39,7 +39,7 @@ function LastUpdated() {
     lastUpdated && (
       <div>
         <Typography variant="body2" className={classes.lastUpdated}>
-          Data last updated&nbsp;
+          Data&nbsp;last&nbsp;updated&nbsp;
           {moment(lastUpdated).format('MM/DD/YY')}
         </Typography>
       </div>

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -46,7 +46,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-// TODO: check with UI/UX re placement of social media, privacy policy links
 function Footer() {
   const classes = useStyles();
   const currentDate = new Date();

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
@@ -65,7 +65,7 @@ function Footer() {
               const nonBreakingText = text.replaceAll(' ', '\u00a0');
 
               return (
-                <React.Fragment key={text}>
+                <Fragment key={text}>
                   {href ? (
                     <Link to={href} className={classes.link}>
                       {nonBreakingText}
@@ -75,7 +75,7 @@ function Footer() {
                   )}
 
                   {i === footerItems.length - 1 ? null : <span>|</span>}
-                </React.Fragment>
+                </Fragment>
               );
             })}
           </Typography>

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -5,6 +5,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { Link } from 'react-router-dom';
 import LastUpdated from '@components/Footer/LastUpdated';
 import SocialMediaLinks from '@components/Footer/SocialMediaLinks';
+import { toNonBreakingSpaces } from '@utils';
 import HFLALogo from '@assets/hack_for_la_logo.png';
 
 // Footer should make use of style overrides to look the same regardless of light/dark theme.
@@ -62,7 +63,7 @@ function Footer() {
         <div className={classes.copyrightContainer}>
           <Typography variant="body2" className={classes.copyright}>
             {footerItems.map(({ text, href }, i) => {
-              const nonBreakingText = text.replaceAll(' ', '\u00a0');
+              const nonBreakingText = toNonBreakingSpaces(text);
 
               return (
                 <Fragment key={text}>

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -5,6 +5,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { Link } from 'react-router-dom';
 import LastUpdated from '@components/Footer/LastUpdated';
 import SocialMediaLinks from '@components/Footer/SocialMediaLinks';
+import HFLALogo from '@assets/hack_for_la_logo.png';
 
 // Footer should make use of style overrides to look the same regardless of light/dark theme.
 const useStyles = makeStyles(theme => ({
@@ -34,6 +35,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',
+    alignItems: 'center',
   },
   link: {
     color: theme.palette.text.dark,
@@ -58,8 +60,11 @@ function Footer() {
             <Link to="/privacy" className={classes.link}>
               Privacy Policy
             </Link>
-            &nbsp;&nbsp;|&nbsp;&nbsp;Powered by volunteers from Hack for LA
+            &nbsp;&nbsp;|&nbsp;&nbsp;Powered by volunteers from Hack for
+            LA&nbsp;&nbsp;
           </Typography>
+
+          <img src={HFLALogo} alt="Hack for LA logo" width="24" />
         </div>
 
         <LastUpdated />

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -49,25 +49,35 @@ const useStyles = makeStyles(theme => ({
 function Footer() {
   const classes = useStyles();
   const currentDate = new Date();
+  const footerItems = [
+    { text: `\u00a9 ${currentDate.getFullYear()} 311 Data` },
+    { text: 'All Rights Reserved' },
+    { text: 'Privacy Policy', href: '/privacy' },
+    { text: 'Powered by volunteers from Hack for LA' },
+  ];
 
   return (
     <footer className={classes.footer}>
       <div className={classes.container}>
         <div className={classes.copyrightContainer}>
           <Typography variant="body2" className={classes.copyright}>
-            <span>
-              &copy;&nbsp;{currentDate.getFullYear()}&nbsp;311&nbsp;Data
-            </span>
-            <span>|</span>
-            <span>All&nbsp;Rights&nbsp;Reserved</span>
-            <span>|</span>
-            <Link to="/privacy" className={classes.link}>
-              Privacy&nbsp;Policy
-            </Link>
-            <span>|</span>
-            <span>
-              Powered&nbsp;by&nbsp;volunteers&nbsp;from&nbsp;Hack&nbsp;for&nbsp;LA
-            </span>
+            {footerItems.map(({ text, href }, i) => {
+              const nonBreakingText = text.replaceAll(' ', '\u00a0');
+
+              return (
+                <React.Fragment key={text}>
+                  {href ? (
+                    <Link to={href} className={classes.link}>
+                      {nonBreakingText}
+                    </Link>
+                  ) : (
+                    <span>{nonBreakingText}</span>
+                  )}
+
+                  {i === footerItems.length - 1 ? null : <span>|</span>}
+                </React.Fragment>
+              );
+            })}
           </Typography>
 
           <img

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -21,6 +21,8 @@ const useStyles = makeStyles(theme => ({
     height: theme.footer.height,
   },
   copyright: {
+    display: 'flex',
+    gap: theme.spacing(1),
     fontWeight: theme.typography.fontWeightMedium,
     lineHeight: theme.footer.height,
     color: theme.palette.text.dark,
@@ -33,13 +35,14 @@ const useStyles = makeStyles(theme => ({
   },
   copyrightContainer: {
     display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'center',
     alignItems: 'center',
   },
   link: {
     color: theme.palette.text.dark,
     textDecoration: 'none',
+  },
+  logo: {
+    marginInline: theme.spacing(1),
   },
 }));
 
@@ -53,18 +56,27 @@ function Footer() {
       <div className={classes.container}>
         <div className={classes.copyrightContainer}>
           <Typography variant="body2" className={classes.copyright}>
-            &#169;
-            {currentDate.getFullYear()}
-            &nbsp;311 Data&nbsp;&nbsp;|&nbsp;&nbsp;All Rights
-            Reserved&nbsp;&nbsp;|&nbsp;&nbsp;
+            <span>
+              &#169;&nbsp;{currentDate.getFullYear()}&nbsp;311&nbsp;Data
+            </span>
+            <span>|</span>
+            <span>All&nbsp;Rights&nbsp;Reserved</span>
+            <span>|</span>
             <Link to="/privacy" className={classes.link}>
-              Privacy Policy
+              Privacy&nbsp;Policy
             </Link>
-            &nbsp;&nbsp;|&nbsp;&nbsp;Powered by volunteers from Hack for
-            LA&nbsp;&nbsp;
+            <span>|</span>
+            <span>
+              Powered&nbsp;by&nbsp;volunteers&nbsp;from&nbsp;Hack&nbsp;for&nbsp;LA
+            </span>
           </Typography>
 
-          <img src={HFLALogo} alt="Hack for LA logo" width="24" />
+          <img
+            src={HFLALogo}
+            alt="Hack for LA logo"
+            width="24"
+            className={classes.logo}
+          />
         </div>
 
         <LastUpdated />

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -57,7 +57,7 @@ function Footer() {
         <div className={classes.copyrightContainer}>
           <Typography variant="body2" className={classes.copyright}>
             <span>
-              &#169;&nbsp;{currentDate.getFullYear()}&nbsp;311&nbsp;Data
+              &copy;&nbsp;{currentDate.getFullYear()}&nbsp;311&nbsp;Data
             </span>
             <span>|</span>
             <span>All&nbsp;Rights&nbsp;Reserved</span>

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,12 +4,20 @@ import requestTypes from '@root/data/requestTypes';
 
 export default {};
 
-function removeSpaces(str) {
+function replaceSpaces(str, replacement) {
   if (!!str === false || typeof str !== 'string') {
     return null;
   }
 
-  return str.replace(/\s/g, '');
+  return str.replace(/\s/g, replacement);
+}
+
+function removeSpaces(str) {
+  return replaceSpaces(str, '')
+}
+
+export function toNonBreakingSpaces(str) {
+  return replaceSpaces(str, '\u00a0');
 }
 
 export function getTypeIdFromTypeName(typeNameParam = '') {


### PR DESCRIPTION
Fixes #1750 

  - [x] Up to date with `main` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [x] Peer reviewed and approved

Modifies the linebreaking behavior of the footer text on smaller screens. The original footer text, with lots of `&nbsp;` entities between each text item, would break to new lines whenever the viewport isn't wide enough (this occurred in `LastUpdated` too). Also placement/amount of `&nbsp;`s was inconsistent, and they made the source code difficult to read. The new text layout:

- defines strings in a new variable `footerItems`, which gets spaces replaced with non-breaking spaces in JSX so that footer text is easier to read when it needs to be updated
- uses MUI spacing tokens to enforce consistent gaps between text, `|` separators, and the logo

Is it the case that we only support large screens? If so, is this new linebreaking behavior acceptable?

<details>
  <summary>screenshot of Figma (from issue description)</summary>
  <img src="https://private-user-images.githubusercontent.com/69279538/331041215-bcb20e67-ab5b-4941-a3bd-399a552f9dd6.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTgxNDgxMzgsIm5iZiI6MTcxODE0NzgzOCwicGF0aCI6Ii82OTI3OTUzOC8zMzEwNDEyMTUtYmNiMjBlNjctYWI1Yi00OTQxLWEzYmQtMzk5YTU1MmY5ZGQ2LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MTElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjExVDIzMTcxOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWYyMjEwMWI0ZWZlMjJmNjA4YmJkMzcwMTkxN2ZhMGVhNThmMzhmZjU0NmQ4M2NiNTcyMWVlNDY0ZDBiYjc0MjEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.Kd2qX6Ykr2T7h0HqyxfXCbyTPGJkmBH5_-1TygsT4as" alt="Figma screenshot" />
</details>

## Footer's responsive behavior after first commit

https://github.com/hackforla/311-data/assets/9038965/7aefd66d-6610-47b1-9d70-0d94d2cd04e0

## Footer's responsive behavior after refactoring

https://github.com/hackforla/311-data/assets/9038965/e3c5eaaa-21ab-461a-8ed5-3b471778fdcd