### PR TITLE
1759 restrict future date selection

### DIFF
--- a/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -2,8 +2,7 @@ import 'react-day-picker/lib/style.css';
 
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
-import Alert from '@mui/material/Alert';
+import React, { useState } from 'react';
 import DayPicker from 'react-day-picker';
 import { connect } from 'react-redux';
 import makeStyles from '@mui/styles/makeStyles';
@@ -162,40 +161,13 @@ function ReactDayPicker({
 
   // enteredTo represents the day that the user is currently hovering over.
   const [enteredTo, setEnteredTo] = useState(endDate);
-  const [error, setError] = useState(null);
 
-  useEffect (() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        setError(null);
-      }, 2000);
-      return () => clearTimeout(timer);
-    }
-  }, [error]);
-
-  const isDateValid = date => {
-    const currentDate = new Date();
-    currentDate.setHours(0, 0, 0, 0);
-    const inputDate = new Date(date);
-    inputDate.setHours(0, 0, 0, 0);
-    return inputDate <= currentDate;
-  };
   const setFromDay = day => {
-    if (isDateValid(day)) {
-      updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
-      setError(null);
-    } else {
-      setError('Error: Date cannot be in the future.');
-    }
+    updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
   };
 
   const setToDay = day => {
-    if (isDateValid(day)) {
-      updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
-      setError(null);
-    } else {
-      setError('Error: Date cannot be in the future.');
-    }
+    updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
   };
 
   const handleDayClick = day => {
@@ -241,13 +213,6 @@ function ReactDayPicker({
   return (
     <>
       {/* <Styles range={range} /> */}
-      {
-        error && (
-          <Alert severity="error">
-            <p>{error}</p>
-          </Alert>
-        )
-      }
       <DayPicker
         // className="Range"
         className={clsx(classes.root, range && classes.hasRange, !range && classes.noRange)}

--- a/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -1,4 +1,5 @@
 import 'react-day-picker/lib/style.css';
+
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';

--- a/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles(theme => ({
 
     '& .DayPicker-Day--disabled': {
       color: colors.textSecondaryDark,
-      pointerEvents: 'none !important',
+      pointerEvents: 'none',
     },
 
     /* Day cell hover */
@@ -208,7 +208,9 @@ function ReactDayPicker({
   const from = moment(startDate).toDate();
   const enteredToDate = moment(enteredTo).toDate();
   const today = new Date();
-  const lastThreeMonths = new Date(today.getFullYear(), today.getMonth() - 3, today.getDate());
+  const currentMonth = today.getFullYear();
+  const currentYear = today.getMonth();
+  const lastThreeMonths = new Date(currentYear, currentMonth - 3, today.getDate());
 
   return (
     <>
@@ -224,6 +226,7 @@ function ReactDayPicker({
         onDayMouseEnter={handleDayMouseEnter}
         weekdayElement={<WeekDay />}
         fromMonth={new Date(2019, 12)}
+        toMonth={new Date(currentMonth, currentYear)}
       />
     </>
   );

--- a/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -52,6 +52,7 @@ const useStyles = makeStyles(theme => ({
 
     '& .DayPicker-Day--disabled': {
       color: colors.textSecondaryDark,
+      pointerEvents: 'none !important',
     },
 
     /* Day cell hover */

--- a/components/common/ReactDayPicker/ReactDayPicker.jsx
+++ b/components/common/ReactDayPicker/ReactDayPicker.jsx
@@ -1,8 +1,8 @@
 import 'react-day-picker/lib/style.css';
-
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import Alert from '@mui/material/Alert';
 import DayPicker from 'react-day-picker';
 import { connect } from 'react-redux';
 import makeStyles from '@mui/styles/makeStyles';
@@ -160,13 +160,40 @@ function ReactDayPicker({
 
   // enteredTo represents the day that the user is currently hovering over.
   const [enteredTo, setEnteredTo] = useState(endDate);
+  const [error, setError] = useState(null);
 
+  useEffect (() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        setError(null);
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [error]);
+
+  const isDateValid = date => {
+    const currentDate = new Date();
+    currentDate.setHours(0, 0, 0, 0);
+    const inputDate = new Date(date);
+    inputDate.setHours(0, 0, 0, 0);
+    return inputDate <= currentDate;
+  };
   const setFromDay = day => {
-    updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
+    if (isDateValid(day)) {
+      updateStartDate(moment(day).format(INTERNAL_DATE_SPEC));
+      setError(null);
+    } else {
+      setError('Error: Date cannot be in the future.');
+    }
   };
 
   const setToDay = day => {
-    updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
+    if (isDateValid(day)) {
+      updateEndDate(moment(day).format(INTERNAL_DATE_SPEC));
+      setError(null);
+    } else {
+      setError('Error: Date cannot be in the future.');
+    }
   };
 
   const handleDayClick = day => {
@@ -212,6 +239,13 @@ function ReactDayPicker({
   return (
     <>
       {/* <Styles range={range} /> */}
+      {
+        error && (
+          <Alert severity="error">
+            <p>{error}</p>
+          </Alert>
+        )
+      }
       <DayPicker
         // className="Range"
         className={clsx(classes.root, range && classes.hasRange, !range && classes.noRange)}

--- a/components/main/Desktop/FilterMenu.js
+++ b/components/main/Desktop/FilterMenu.js
@@ -17,10 +17,6 @@ import StatusSelector from '@components/main/Desktop/StatusSelector';
 import CouncilSelector from '@components/main/Desktop/CouncilSelector';
 import ShareableLinkCreator from '@components/main/Desktop/ShareableLinkCreator';
 import ExportButton from '@components/main/Desktop/ExportButton';
-
-// import GearButton from '@components/common/GearButton';
-// import clsx from 'clsx';
-
 import sharedStyles from '@theme/styles';
 
 const useStyles = makeStyles(theme => ({
@@ -121,12 +117,12 @@ function FilterMenu({ resetMap, resetAddressSearch }) {
           <div className={classes.selectorWrapper}>
             <StatusSelector />
           </div>
-          <div className={classes.selectorWrapper}>
+          {/* <div className={classes.selectorWrapper}>
             <ShareableLinkCreator />
-          </div>
-          <div className={classes.selectorWrapper}>
+          </div> */}
+          {/* <div className={classes.selectorWrapper}>
             <ExportButton />
-          </div>
+          </div> */}
         </CardContent>
       </Collapse>
     </Card>

--- a/components/main/Desktop/FilterMenu.js
+++ b/components/main/Desktop/FilterMenu.js
@@ -15,8 +15,8 @@ import DateSelector from '@components/DateSelector/DateSelector';
 import TypeSelector from '@components/main/Desktop/TypeSelector';
 import StatusSelector from '@components/main/Desktop/StatusSelector';
 import CouncilSelector from '@components/main/Desktop/CouncilSelector';
-// import ShareableLinkCreator from '@components/main/Desktop/ShareableLinkCreator';
-// import ExportButton from '@components/main/Desktop/ExportButton';
+import ShareableLinkCreator from '@components/main/Desktop/ShareableLinkCreator';
+import ExportButton from '@components/main/Desktop/ExportButton';
 
 // import GearButton from '@components/common/GearButton';
 // import clsx from 'clsx';
@@ -121,12 +121,12 @@ function FilterMenu({ resetMap, resetAddressSearch }) {
           <div className={classes.selectorWrapper}>
             <StatusSelector />
           </div>
-          {/* <div className={classes.selectorWrapper}>
+          <div className={classes.selectorWrapper}>
             <ShareableLinkCreator />
-          </div> */}
-          {/* <div className={classes.selectorWrapper}>
+          </div>
+          <div className={classes.selectorWrapper}>
             <ExportButton />
-          </div> */}
+          </div>
         </CardContent>
       </Collapse>
     </Card>

--- a/components/main/Desktop/FilterMenu.js
+++ b/components/main/Desktop/FilterMenu.js
@@ -15,8 +15,12 @@ import DateSelector from '@components/DateSelector/DateSelector';
 import TypeSelector from '@components/main/Desktop/TypeSelector';
 import StatusSelector from '@components/main/Desktop/StatusSelector';
 import CouncilSelector from '@components/main/Desktop/CouncilSelector';
-import ShareableLinkCreator from '@components/main/Desktop/ShareableLinkCreator';
-import ExportButton from '@components/main/Desktop/ExportButton';
+// import ShareableLinkCreator from '@components/main/Desktop/ShareableLinkCreator';
+// import ExportButton from '@components/main/Desktop/ExportButton';
+
+// import GearButton from '@components/common/GearButton';
+// import clsx from 'clsx';
+
 import sharedStyles from '@theme/styles';
 
 const useStyles = makeStyles(theme => ({


### PR DESCRIPTION
Fixes #1759

### Issue
Users can select past the current date and still have the page render data. 

### Changes

Future months/days are not possible from the current date since they are not selectable.

  - [x] Up to date with `main` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [x] Peer reviewed and approved