### PR TITLE
1783 header active while modal active

### DIFF
--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles(theme => ({
     height: theme.footer.height,
     width: '100%',
     backgroundColor: theme.palette.primary.dark,
-    zIndex: 1,
+    zIndex: 1400,
   },
   footerSpacing: {
     height: theme.footer.height,

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles(theme => ({
     height: theme.header.height,
     backgroundColor: theme.palette.primary.main,
     position: 'relative',
-    zIndex: 14000,
+    zIndex: 1400,
   },
   link: {
     color: 'white',

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -20,6 +20,8 @@ const useStyles = makeStyles(theme => ({
   appBar: {
     height: theme.header.height,
     backgroundColor: theme.palette.primary.main,
+    position: 'relative',
+    zIndex: 14000,
   },
   link: {
     color: 'white',


### PR DESCRIPTION
Fixes #1783 

### Info
Display the Header (navbar) while a modal is active. 

**Update:** Added Footer visibility using the same zIndex value.

### Changes Made
Updated the Header component with a z-index value that is higher than the modal z-index.

- Added `position: 'relative'` and `zIndex: 1400` to Header (AppBar MUI).
-- Value is defined based on MUI component zIndex hierarchy.

Screenshot of UI change:
<p>

Loading Modal Visible Header/Footer
![onload](https://github.com/user-attachments/assets/cfb8805b-3445-43ff-9308-6ced73104d64)

Acknowledge Modal Visible Header/Footer
![modal](https://github.com/user-attachments/assets/6a96f4e5-1906-4f60-a314-2c2ee36ad8f8)

</p>

Resources: 
https://mui.com/material-ui/customization/z-index/

### Pre-merge Checklist
  - [x] Up to date with `main` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [x] Peer reviewed and approved
