### PR TITLE
1840 searching outside nc boundary silently fails

### DIFF
--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -583,8 +583,6 @@ class Map extends React.Component {
         this.setState({
           address: address,
         });
-        console.log('address if not found', this.state.address)
-       //depending on the number it'll zoom to that nc location
         this.map.flyTo({
           center: [longitude, latitude],
           essential: true,

--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -569,10 +569,10 @@ class Map extends React.Component {
           throw new Error('Council Id in address search geocoder result could not be found');
         }
         const newSelected = [newSelectedCouncil];
-        dispatchUpdateSelectedCouncils(newSelected); //this doesn't control the zoom in
-        dispatchUpdateUnselectedCouncils(councils);  //this doesn't controlt he zoom
+        dispatchUpdateSelectedCouncils(newSelected);
+        dispatchUpdateUnselectedCouncils(councils);
         
-        dispatchUpdateNcId(Number(ncIdOfAddressSearch)); //this contorls the zoom
+        dispatchUpdateNcId(Number(ncIdOfAddressSearch));
         this.setState({
           address: address,
         });

--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -569,15 +569,27 @@ class Map extends React.Component {
           throw new Error('Council Id in address search geocoder result could not be found');
         }
         const newSelected = [newSelectedCouncil];
-        dispatchUpdateSelectedCouncils(newSelected);
-        dispatchUpdateUnselectedCouncils(councils);
+        dispatchUpdateSelectedCouncils(newSelected); //this doesn't control the zoom in
+        dispatchUpdateUnselectedCouncils(councils);  //this doesn't controlt he zoom
         
-        dispatchUpdateNcId(Number(ncIdOfAddressSearch));
+        dispatchUpdateNcId(Number(ncIdOfAddressSearch)); //this contorls the zoom
         this.setState({
           address: address,
         });
 
         // Add that cute House Icon on the map
+        return this.addressLayer.addMarker([longitude, latitude]);
+      } else {
+        this.setState({
+          address: address,
+        });
+        console.log('address if not found', this.state.address)
+       //depending on the number it'll zoom to that nc location
+        this.map.flyTo({
+          center: [longitude, latitude],
+          essential: true,
+          zoom: 9,
+      });
         return this.addressLayer.addMarker([longitude, latitude]);
       }
     }


### PR DESCRIPTION
Fixes #1840

Issue
If addresses are not in NC boundaries, the user may not always know.  

Changes
The house icon will still display if the address is not inside an NC boundary region.

![CPT2410260100-800x461](https://github.com/user-attachments/assets/8a882c88-90c8-42ad-b2fe-156cf97c935f)

  - [X] Up to date with `main` branch
  - [X] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [X] All PR Status checks are successful
  - [ ] Peer reviewed and approved

