### PR TITLE
1540 Handle zooming in on MultiPolygon NCs

### DIFF
--- a/components/Map/geoUtils.js
+++ b/components/Map/geoUtils.js
@@ -8,6 +8,7 @@ import {
   polygon,
   pointsWithinPolygon,
   booleanPointInPolygon,
+  multiPolygon,
 } from '@turf/turf';
 
 import ncGeojson from '@data/ncGeojson';
@@ -68,20 +69,20 @@ export function getNcByLngLatv2({
     const features = ncGeojson.features;
     console.log({ features });
 
-    // TODO: Be able to handle MultiPolygons instead of skipping over them
-    // [ECHO PARK NC, NC VALLEY VILLAGE] are the only 2 MultiPolygons
-    const ncGeoArray = features.filter(
-      (feature) => feature.geometry.type !== 'MultiPolygon'
-    );
-    console.log({ ncGeoArray });
+    let foundNcGeoObj;
 
-    const foundNcGeoObj = ncGeoArray.find((ncGeoObj) =>
-      booleanPointInPolygon(
-        point([longitude, latitude]),
-        polygon(ncGeoObj.geometry.coordinates)
-      )
-    );
+    for (const feature of features) {
+      let featurePolygon;
+      if (feature.geometry.type == 'MultiPolygon')
+        featurePolygon = multiPolygon(feature.geometry.coordinates);
+      else {
+        featurePolygon = polygon(feature.geometry.coordinates);
+      }
 
+      if (booleanPointInPolygon(point([longitude, latitude]), featurePolygon)) {
+        foundNcGeoObj = feature
+      }
+    }
     console.log({ foundNcGeoObj });
 
     return foundNcGeoObj?.properties?.NC_ID;


### PR DESCRIPTION
Fixes #1540 

### Info
`ECHO PARK NC` and `NC VALLEY VILLAGE` are classified as MultiPolygons and won't zoom in when searched for in the Address Search. I found [this section of geoUtils.js](https://github.com/hackforla/311-data/blob/eee59bbf2de9f700db0305e4e158cb520ae4b15a/components/Map/geoUtils.js#L71-L83) that filters out the two `MultiPolygon` NCs since they weren't working with `booleanPointInPolygon`. 

### Changes Made
[`booleanPointInPolygon`](https://turfjs.org/docs/api/booleanPointInPolygon) can take a polygon or multipolygon, but the feature type needs to be specified. We can use a for loop with a conditional so we can use either `polygon(feature.geometry.coordinates)`  or `multiPolygon(feature.geometry.coordinates)` with `booleanPointInPolygon`. 

With the change I checked an address in Echo Park (1226 N Alvarado, Los Angeles, CA 90026), one in Valley Village (5000 Colfax Avenue, Valley Village, CA 91607), and one outside of either of those NCs, and they all zoomed in properly. (The addresses in Echo Park and Valley Village do not zoom in with the current codebase without this fix). 

### Pre-merge Checklist

  - [ ] Up to date with `main` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
