### PR TITLE
1902 de select nc selection on outside click

### DIFF
--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -454,6 +454,8 @@ class Map extends React.Component {
 
     // Set councilId in reducers/filters back to null
     dispatchUpdateNcId(null);
+    console.log('this.props', this.props)
+    updateSelectedCouncils([])
 
     this.map.once('zoomend', () => {
       this.setState({
@@ -478,7 +480,6 @@ class Map extends React.Component {
     dispatchUpdateNcId(null);
 
     // Reset councilSelector.
-    dispatchUpdateSelectedCouncils([]);
     dispatchUpdateUnselectedCouncils(councils);
   };
 
@@ -559,6 +560,7 @@ class Map extends React.Component {
 
     if (!features.length) {
       this.reset()
+      dispatchUpdateSelectedCouncils([]);
     } else {
       for (let i = 0; i < features.length; i += 1) {
         const feature = features[i];

--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -454,8 +454,6 @@ class Map extends React.Component {
 
     // Set councilId in reducers/filters back to null
     dispatchUpdateNcId(null);
-    console.log('this.props', this.props)
-    updateSelectedCouncils([])
 
     this.map.once('zoomend', () => {
       this.setState({


### PR DESCRIPTION
Fixes #1904 

What changes did you make?

If someone clicks on a NC and then clicks outside of a valid NC, the Boundaries selection resets.

Why did you make the changes?

Initially, when a user clicks outside of an invalid NC it would zoom out, but not clear the input under Boundaries.  This was a bug and was fixed in this pull request.

  - [x] Up to date with `main` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [x] All PR Status checks are successful
  - [ ] Peer reviewed and approved
