### PR TITLE
One request table v2 1891

### DIFF
--- a/components/Footer/LastUpdated.jsx
+++ b/components/Footer/LastUpdated.jsx
@@ -21,7 +21,7 @@ function LastUpdated() {
 
   useEffect(() => {
     const getLastUpdated = async () => {
-      const getLastUpdatedSQL = 'select max(createddate) from requests_2025;';
+      const getLastUpdatedSQL = 'select max(createddate) from requests;';
 
       const lastUpdatedAsArrowTable = await conn.query(getLastUpdatedSQL);
       const results = ddbh.getTableData(lastUpdatedAsArrowTable);

--- a/components/Map/index.jsx
+++ b/components/Map/index.jsx
@@ -28,6 +28,7 @@ import moment from 'moment';
 import ddbh from '@utils/duckDbHelpers.js';
 import DbContext from '@db/DbContext';
 import AcknowledgeModal from '../Loading/AcknowledgeModal';
+import { createRequestsTable, fetchData } from '../db/DbRequests';
 
 // We make API requests on a per-day basis. On average, there are about 4k
 // requests per day, so 10k is a large safety margin.
@@ -66,36 +67,12 @@ class MapContainer extends React.Component {
     this.endTime = 0;
   }
 
-  createRequestsTable = async () => {
-    this.setState({ isTableLoading: true });
-    const { conn, tableNameByYear, setDbStartTime } = this.context;
-    const startDate = this.props.startDate; // directly use the startDate prop transformed for redux store
-    const year = moment(startDate).year(); // extract the year
-    const datasetFileName = `requests${year}.parquet`;
-
-    // Create the year data table if not exist already
-    const createSQL =
-      `CREATE TABLE IF NOT EXISTS ${tableNameByYear} AS SELECT * FROM "${datasetFileName}"`; // query from parquet
-
-    const startTime = performance.now(); // start the time tracker
-    setDbStartTime(startTime)
-
-      try {
-        await conn.query(createSQL);
-        const endTime = performance.now() // end the timer
-        console.log(`Dataset registration & table creation (by year) time: ${Math.floor(endTime - startTime)} ms.`);
-      } catch (error) {
-        console.error("Error in creating table or registering dataset:", error);
-      } finally {
-        this.setState({ isTableLoading: false});
-      }
-  };
-
   async componentDidMount(props) {
     this.isSubscribed = true;
     this.processSearchParams();
-    await this.createRequestsTable();
+    await createRequestsTable({ conn: this.context.conn, setDbStartTime: this.context.setDbStartTime }, this.setState.bind(this));
     await this.setData();
+    await this.testFetchData();
   }
 
   async componentDidUpdate(prevProps) {
@@ -114,8 +91,9 @@ class MapContainer extends React.Component {
       prevProps.pins !== pins ||
       didDateRangeChange
     ) {
-      await this.createRequestsTable();
+      await createRequestsTable({ conn: this.context.conn, setDbStartTime: this.context.setDbStartTime }, this.setState.bind(this));
       await this.setData();
+      await this.testFetchData();
     }
   }
 
@@ -315,29 +293,9 @@ class MapContainer extends React.Component {
 
   async getAllRequests(startDate, endDate) {
     const { conn } = this.context;
-    const startYear = moment(startDate).year();
-    const endYear = moment(endDate).year();
-
-    let selectSQL = '';
 
     try {
-      if (startYear === endYear) {
-        // If the dates are within the same year, query that single year's table.
-        const tableName = `requests_${startYear}`;
-        selectSQL = `SELECT * FROM ${tableName} WHERE CreatedDate BETWEEN '${startDate}' AND '${endDate}'`;
-      } else {
-        // If the dates span multiple years, create two queries and union them.
-        const tableNameStartYear = `requests_${startYear}`;
-        const endOfStartYear = moment(startDate).endOf('year').format('YYYY-MM-DD');
-        const tableNameEndYear = `requests_${endYear}`;
-        const startOfEndYear = moment(endDate).startOf('year').format('YYYY-MM-DD');
-
-        selectSQL = `
-          (SELECT * FROM ${tableNameStartYear} WHERE CreatedDate BETWEEN '${startDate}' AND '${endOfStartYear}')
-          UNION ALL
-          (SELECT * FROM ${tableNameEndYear} WHERE CreatedDate BETWEEN '${startOfEndYear}' AND '${endDate}')
-        `;
-      }
+      const selectSQL = `SELECT * FROM requests WHERE CreatedDate BETWEEN '${startDate}' AND '${endDate}'`;
 
       const dataLoadStartTime = performance.now();
       const requestsAsArrowTable = await conn.query(selectSQL);
@@ -355,7 +313,48 @@ class MapContainer extends React.Component {
       console.error("Error during database query execution:", e);
     }
   }
+  // async getAllRequests(startDate, endDate) {
+  //   const { conn } = this.context;
+  //   const startYear = moment(startDate).year();
+  //   const endYear = moment(endDate).year();
 
+  //   let selectSQL = '';
+
+  //   try {
+  //     if (startYear === endYear) {
+  //       // If the dates are within the same year, query that single year's table.
+  //       const tableName = `requests_${startYear}`;
+  //       selectSQL = `SELECT * FROM ${tableName} WHERE CreatedDate BETWEEN '${startDate}' AND '${endDate}'`;
+  //     } else {
+  //       // If the dates span multiple years, create two queries and union them.
+  //       const tableNameStartYear = `requests_${startYear}`;
+  //       const endOfStartYear = moment(startDate).endOf('year').format('YYYY-MM-DD');
+  //       const tableNameEndYear = `requests_${endYear}`;
+  //       const startOfEndYear = moment(endDate).startOf('year').format('YYYY-MM-DD');
+
+  //       selectSQL = `
+  //         (SELECT * FROM ${tableNameStartYear} WHERE CreatedDate BETWEEN '${startDate}' AND '${endOfStartYear}')
+  //         UNION ALL
+  //         (SELECT * FROM ${tableNameEndYear} WHERE CreatedDate BETWEEN '${startOfEndYear}' AND '${endDate}')
+  //       `;
+  //     }
+
+  //     const dataLoadStartTime = performance.now();
+  //     const requestsAsArrowTable = await conn.query(selectSQL);
+  //     const dataLoadEndTime = performance.now();
+
+  //     console.log(`Data loading time: ${Math.floor(dataLoadEndTime - dataLoadStartTime)} ms`);
+
+  //     const requests = ddbh.getTableData(requestsAsArrowTable);
+  //     const mapLoadEndTime = performance.now();
+
+  //     console.log(`Map loading time: ${Math.floor(mapLoadEndTime - dataLoadEndTime)} ms`);
+
+  //     return requests;
+  //   } catch (e) {
+  //     console.error("Error during database query execution:", e);
+  //   }
+  // }
 
   setData = async () => {
     const { startDate, endDate, dispatchGetDbRequest, dispatchGetDataRequest } =
@@ -384,6 +383,14 @@ class MapContainer extends React.Component {
       dispatchUpdateDateRanges(newDateRangesWithRequests);
     }
   };
+
+  testFetchData = async () => {
+    const data = await fetchData(
+      { conn: this.context.conn },
+      { startDate: "2023-01-01", endDate: "2023-12-31", requestType: "Graffiti" }
+    );
+    console.log(`testFetchData ran in components/Map/index.jsx`);
+  }
 
   convertRequests = (requests) =>
     requests.map((request) => {

--- a/components/Map/index.jsx
+++ b/components/Map/index.jsx
@@ -313,48 +313,6 @@ class MapContainer extends React.Component {
       console.error("Error during database query execution:", e);
     }
   }
-  // async getAllRequests(startDate, endDate) {
-  //   const { conn } = this.context;
-  //   const startYear = moment(startDate).year();
-  //   const endYear = moment(endDate).year();
-
-  //   let selectSQL = '';
-
-  //   try {
-  //     if (startYear === endYear) {
-  //       // If the dates are within the same year, query that single year's table.
-  //       const tableName = `requests_${startYear}`;
-  //       selectSQL = `SELECT * FROM ${tableName} WHERE CreatedDate BETWEEN '${startDate}' AND '${endDate}'`;
-  //     } else {
-  //       // If the dates span multiple years, create two queries and union them.
-  //       const tableNameStartYear = `requests_${startYear}`;
-  //       const endOfStartYear = moment(startDate).endOf('year').format('YYYY-MM-DD');
-  //       const tableNameEndYear = `requests_${endYear}`;
-  //       const startOfEndYear = moment(endDate).startOf('year').format('YYYY-MM-DD');
-
-  //       selectSQL = `
-  //         (SELECT * FROM ${tableNameStartYear} WHERE CreatedDate BETWEEN '${startDate}' AND '${endOfStartYear}')
-  //         UNION ALL
-  //         (SELECT * FROM ${tableNameEndYear} WHERE CreatedDate BETWEEN '${startOfEndYear}' AND '${endDate}')
-  //       `;
-  //     }
-
-  //     const dataLoadStartTime = performance.now();
-  //     const requestsAsArrowTable = await conn.query(selectSQL);
-  //     const dataLoadEndTime = performance.now();
-
-  //     console.log(`Data loading time: ${Math.floor(dataLoadEndTime - dataLoadStartTime)} ms`);
-
-  //     const requests = ddbh.getTableData(requestsAsArrowTable);
-  //     const mapLoadEndTime = performance.now();
-
-  //     console.log(`Map loading time: ${Math.floor(mapLoadEndTime - dataLoadEndTime)} ms`);
-
-  //     return requests;
-  //   } catch (e) {
-  //     console.error("Error during database query execution:", e);
-  //   }
-  // }
 
   setData = async () => {
     const { startDate, endDate, dispatchGetDbRequest, dispatchGetDataRequest } =

--- a/components/db/DbRequests.jsx
+++ b/components/db/DbRequests.jsx
@@ -1,0 +1,117 @@
+const createRequestsTable = async ({conn, setDbStartTime}, setState) => {
+  setState({ isTableLoading: true });
+
+  // define the requests table if it doesn't already exist
+  const createSQL = `
+    CREATE TABLE IF NOT EXISTS requests (
+      SRNumber VARCHAR,
+      CreatedDate DATETIME,
+      UpdatedDate DATETIME,
+      ActionTaken VARCHAR,
+      Owner VARCHAR,
+      RequestType VARCHAR,
+      Status VARCHAR,
+      RequestSource VARCHAR,
+      CreatedByUserOrganization VARCHAR,
+      MobileOS VARCHAR,
+      Anonymous VARCHAR,
+      AssignTo VARCHAR,
+      ServiceDate DATETIME,
+      ClosedDate DATETIME,
+      AddressVerified VARCHAR,
+      ApproximateAddress VARCHAR,
+      Address VARCHAR,
+      HouseNumber VARCHAR,
+      Direction VARCHAR,
+      StreetName VARCHAR,
+      Suffix VARCHAR,
+      ZipCode VARCHAR,
+      Latitude DECIMAL(8),
+      Longitude DECIMAL(8),
+      Location VARCHAR,
+      TBMPage VARCHAR,
+      TBMColumn VARCHAR,
+      TBMRow VARCHAR,
+      APC VARCHAR,
+      CD VARCHAR,
+      CDMember VARCHAR,
+      NC VARCHAR,
+      NCName VARCHAR,
+      PolicePrecinct VARCHAR,
+    )
+  `;
+
+  const startTime = performance.now();
+  setDbStartTime(startTime);
+
+    try {
+      await conn.query(createSQL);
+      const endTime = performance.now();
+      console.log(`Dataset registration & table creation (by year) time: ${Math.floor(endTime - startTime)} ms.`);
+    } catch (error) {
+      console.error("Error in creating table or registering dataset:", error);
+    } finally {
+      setState({ isTableLoading: false });
+    }
+};
+
+/**
+ * `fetchData` is a placeholder function to request data when given a set of filter params. e.g: date range(s), SR type, SR status, NC.
+ * once fleshed out, it will replace the `setData` function in `components/Map/index.jsx` and will be the accessor method for fetching data from external sources (e.g. Socrata, Huggingface)
+ *
+ * Fetches data from DuckDB using provided filters.
+ *
+ * @param {Object} conn - The DuckDB connection instance.
+ * @param {Object} filters - An object containing any or none of the following filter parameters:
+ *    - startDate: (string) Start of date range (YYYY-MM-DD)
+ *    - endDate: (string) End of date range (YYYY-MM-DD)
+ *    - requestType: (string) Filter by request type
+ *    - status: (string) Filter by status
+ *    - ncName: (string) Filter by neighborhood council (NC)
+ *
+ * Example Usage:
+ * fetchData({ conn }, { startDate: "2023-01-01", endDate: "2023-12-31", requestType: "Graffiti" });
+ */
+  const fetchData = async ({ conn }, filters = {}) => {
+    try {
+      // Step 1: Log table structure as proof of concept
+      console.log("Fetching table schema...");
+      const schemaResult = await conn.query("DESCRIBE requests");
+      console.log(schemaResult.toString());
+
+      // Step 2: Construct SQL Query with Filters
+      let query = "SELECT * FROM requests WHERE 1=1"; // `1=1` allows appending conditions dynamically
+
+      if (filters.startDate) {
+        query += ` AND CreatedDate >= '${filters.startDate}'`;
+      }
+      if (filters.endDate) {
+        query += ` AND CreatedDate <= '${filters.endDate}'`;
+      }
+      if (filters.requestType) {
+        query += ` AND RequestType = '${filters.requestType}'`;
+      }
+      if (filters.status) {
+        query += ` AND Status = '${filters.status}'`;
+      }
+      if (filters.ncName) {
+        query += ` AND NCName = '${filters.ncName}'`;
+      }
+
+      console.log("Executing query:", query);
+
+      // Step 3: Run Query
+      const result = await conn.query(query);
+
+      // Step 4: Convert Results to JSON
+      const data = result.toArray(); // Converts ArrowTable to JSON-like array
+      console.log("Fetched Data:", data);
+
+      return data;
+    } catch (error) {
+      console.error("Error fetching data:", error);
+      return [];
+    }
+  };
+
+export { createRequestsTable, fetchData };


### PR DESCRIPTION
Fixes #1891

### What changes did you make?
  - moved the `createRequestsTable` function into a new file, `components/db/DbRequests.jsx`
  - changed the `createRequestsTable` function to create a table, using a manual schema, that is year-agnostic
  - updated the table name across the application to be year-agnostic
  - created a test version of the `fetchData` function in `components/db/DbRequests.jsx` that will serve as a replacement for the `setData` function in `components/Map/index.jsx` once it is fleshed out

### Why did you make the changes?
  - To create a version of the app that initializes the map using one request table instead of one table for each year of data
  - _Note:_ This is VERSION 2 of my previous PR, made onto a new feature branch `feature-one-request-table` due to issues with merge artifacts from the previous PR.

### PR Checks
  - [x] Up to date with `main` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved
