### PR TITLE
added logic to fix map reset

### DIFF
--- a/components/Map/Map.jsx
+++ b/components/Map/Map.jsx
@@ -552,7 +552,9 @@ class Map extends React.Component {
     const features = this.getAllFeaturesAtPoint(e.point);
 
     if (!features.length) {
-      this.reset()
+      if(this.hasDistrictSelected()) {
+        this.reset()
+      }
     } else {
       for (let i = 0; i < features.length; i += 1) {
         const feature = features[i];


### PR DESCRIPTION
Fixes #1919

  - [x] Up to date with `main` branch
  - [x] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)

<details><summary>Screen recording  before fix</summary>

https://github.com/user-attachments/assets/57c4e372-a33d-4a02-af15-6c9477cbb40c

</details> 

<details><summary>Screen recording after fix</summary>

https://github.com/user-attachments/assets/306e85b9-9d3d-43ea-95a7-e45776e6a93e

</details> 

### Testing Instructions:

1.) The outside click reset should only trigger when an NC is selected
2.) Clicking outside without any NC selected should not cause the camera to zoom out

3.) Without Selecting an NC:

  - [ ] Load the map page

  - [ ] Click outside any NC boundaries

  - [ ] Observe that no camera reset or unintended behavior occurs

4.) After Selecting an NC:

  - [ ] Click on a specific NC to select it

  - [ ] Click outside the NC boundaries

  - [ ] Verify that the camera zooms out to the starting position