### PR TITLE
feat: Add 'ready for peer review' label to PM recurring checklist

### DIFF
--- a/.github/PM_RECURRING_CHECKLIST.md
+++ b/.github/PM_RECURRING_CHECKLIST.md
@@ -1,0 +1,44 @@
+# PM Recurring Agenda Items Checklist
+
+## Weekly Checklist
+
+### YYYY-MM-DD Recurring Agenda Items
+- [ ] Update [311 Team Roster](https://docs.google.com/spreadsheets/d/1OsLDl7Ciwj7WjtzbgDz38g4kpOMNlUhdjlgzQxtQTvM/edit?gid=0#gid=0)
+  - [ ] Open views and check if any members need action, see: https://github.com/hackforla/311-data/issues/1494
+    - [ ] `check on website team member changes`
+    - [ ] `inactive remove from website`
+    - [ ] `Permissions to update-drive to viewer`
+    - [ ] `Permissions to update-remove write`
+   - [ ] Review all onboarding issues and see if any onboarding tracking comments are missing checkboxes
+     - [ ] https://github.com/hackforla/311-data/issues/1561
+     - [ ] https://github.com/hackforla/311-data/issues/1578
+     - [ ] https://github.com/hackforla/311-data/issues/1580
+     - [ ] https://github.com/hackforla/311-data/issues/1854
+- [ ] Weekly Label Check: https://github.com/hackforla/311-data/issues/1134
+- [ ] Review each issue in the [Project Board Icebox (temporary view)](https://github.com/orgs/hackforla/projects/63/views/1?filterQuery=status%3A%22Icebox+%28on+hold%29%22)
+  - [ ] Determine if the issue is still blocked. If unblocked, see if it's blocking ticket has a "Releases" section
+  - Q: should we make an issue for Icebox Review weekly audit?
+- [ ] All issues in New Issue Review/Approval have either: 
+    - [ ] The `ready for...` label:  [Project Board: Missing Ready for Labels](https://github.com/orgs/hackforla/projects/63/views/22)
+      - If this link shows any issues in New Issue Approval, they need to be given the appropriate "ready for..." label
+    - [ ] The `draft` label and assignee
+- [ ] All issues in Questions column have a `ready for...` label [Project Board: Missing Ready for Labels](https://github.com/orgs/hackforla/projects/63/views/22)
+  - If this link contains any issues in Questions, they need to be given the appropriate `ready for...` label.
+- [ ] All issues in Review column have a `ready for...` label [Project Board: Missing Ready for Labels](https://github.com/orgs/hackforla/projects/63/views/22)
+  - If this link contains any issues in Review, they need to be given the appropriate `ready for...` label.
+- [ ] **Check for issues with `ready for peer review` label:** [Issues with ready for peer review](https://github.com/hackforla/311-data/issues?q=state%3Aopen%20label%3A%22ready%20for%20peer%20review%22)
+  - [ ] Ensure these issues are visible in relevant Project Board views
+  - [ ] Verify they don't interfere with existing label searches
+  - [ ] Confirm peer review is being tracked properly
+- [ ] Review the issues on [Project Board: Ready for Product](https://github.com/orgs/hackforla/projects/63/views/19)
+  - [ ] address them now or add to this agenda to discuss. 
+- [ ] For each issue in Questions that has `on agenda:` label, add a link to the question-asking comment from each new issue to the the agenda below
+
+## Notes on `ready for peer review` Label
+
+The `ready for peer review` label should be checked weekly to ensure:
+1. Issues with this label are properly tracked in project board views
+2. The label doesn't interfere with existing label searches and filters
+3. Peer review status is visible and actionable for the team
+
+This label is particularly important for maintaining code quality and ensuring proper review processes are followed before merging changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,18 @@ Building on feature branching, we treat the 'main' branch as the primary contrib
 
 In other words, whenever you are about to start on a new feature, checkout a new local branch based off of the main branch. Your command would look something like `git checkout -b 567-BACK-NewEndpoint`. See [this stackoverflow post](https://stackoverflow.com/questions/4470523/create-a-branch-in-git-from-another-branch) for more context.
 
+## Labels and Project Management
+
+We use GitHub labels to organize and track issues throughout their lifecycle. Key labels include:
+
+### Ready for Review Labels
+- `ready for peer review` - Issue/PR is ready for peer review from team members
+- `ready for product` - Issue needs product team review
+- `ready for dev lead` - Issue needs development lead review
+- `ready for design lead` - Issue needs design lead review
+
+These labels help ensure proper review processes are followed and maintain visibility in project board views.
+
 ## Branch Protection/Github Actions (to be implemented)
 We use [Github Actions](https://github.com/features/actions) to run our continuous integration (CI). These actions include status checks that run whenever you submit a pull request to main. When you submit a PR, Github will run a set of operations to build and test all or part of the codebase. If any of these steps fail, the pull request will not be allowed to be merged until they are fixed. From the pull request UI you can find the reason an operation may have failed in the status checks section towards the bottom.
 


### PR DESCRIPTION
## Summary
This PR incorporates the 'ready for peer review' label into the PM recurring agenda checklist as requested.

## Changes Made

### 1. Created PM_RECURRING_CHECKLIST.md
- Added a comprehensive PM recurring checklist based on the template from issue comments
- Included a specific check for issues with the `ready for peer review` label
- Added link to quickly view all issues with this label
- Documented the importance of tracking peer review status

### 2. Updated CONTRIBUTING.md
- Added a new section on 'Labels and Project Management'
- Documented the various 'ready for...' labels including `ready for peer review`
- Explained how these labels help maintain visibility in project board views

## Why These Changes?

The `ready for peer review` label needs to be:
1. Regularly checked during weekly PM audits
2. Visible in relevant Project Board views
3. Not interfering with existing label searches

This PR ensures the label is properly integrated into the team's workflow and project management processes.

## Related Issues
Resolves #2027

## Testing
- [x] Verified markdown formatting is correct
- [x] Checked all links in the checklist template
- [x] Ensured the new documentation is clear and actionable

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings