### PR TITLE
2078: create the current year repo on Huggingface

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,18 @@ brew install act
 
 ```bash
 act -j run --verbose
+```
 
 Use the verbose flag, at least the first time, since the image downloads take so long
+
+## Run the HuggingFace update script locally via Python
+
+```bash
+export HUGGINGFACE_LOGIN_TOKEN=<xxx>
+export VITE_ENV=DEV
+cd src/scripts
+python updateHfDataset.py
+```
 
 ### Information About Technologies
 

--- a/src/scripts/updateHfDataset.py
+++ b/src/scripts/updateHfDataset.py
@@ -102,6 +102,17 @@ def hfUpload(year=None):
 
     login(TOKEN)
     api = HfApi()
+
+    # If the current year's repo doesn't exist, create it
+    # the exist_ok=True flag means we'll ignore any errors if it already exists
+    url = api.create_repo(
+        repo_id=repo_id,
+        token=TOKEN,
+        private=False,
+        repo_type="dataset",
+        exist_ok=True,
+    )
+
     api.upload_file(
         path_or_fileobj=local_filename,
         path_in_repo=dest_filename,


### PR DESCRIPTION
(partially) Fixes #2078 

# Explanation

As part of the huggingface update workflow, we need to ensure that the repo matching the current year exists, otherwise the huggingface update script will fail to upload its parquet file. Added a bit of code to create the repo if it exists (and ignore if it already exists).

# Testing 

Ran it locally and the dataset now exists and is populated with data: https://huggingface.co/datasets/311-Data-Dev/2026

<img width="1087" height="801" alt="image" src="https://github.com/user-attachments/assets/8e7ddef9-fd2f-47a8-828e-f5140b1af6fa" />


  - [ ] Up to date with `main` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
