### PR TITLE
don't hardcode 2025 in lastUpdated

### DIFF
--- a/src/components/layout/Footer/LastUpdated.jsx
+++ b/src/components/layout/Footer/LastUpdated.jsx
@@ -33,7 +33,8 @@ function LastUpdated() {
 
   useEffect(() => {
     const getLastUpdated = async () => {
-      const getLastUpdatedSQL = 'select max(createddate) from requests_2025;';
+      const currentYear = new Date().getFullYear();
+      const getLastUpdatedSQL = `select max(createddate) from requests_${currentYear};`;
       
       const lastUpdatedAsArrowTable = await conn.query(getLastUpdatedSQL);
       const results = ddbh.getTableData(lastUpdatedAsArrowTable);


### PR DESCRIPTION
Fixes bug where duckdb tablename is hardcoded to 2025

  - [ ] Up to date with `main` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
