### PR TITLE
need to set isTableLoading to false once request table is created

### DIFF
--- a/src/features/Map/index.jsx
+++ b/src/features/Map/index.jsx
@@ -90,6 +90,7 @@ class MapContainer extends React.Component {
           endTime - startTime
         )} ms.`
       );
+      this.setState({ isTableLoading: false });
     } catch (error) {
       console.error(`Failed to load dataset for year ${year}:`, error);
     }


### PR DESCRIPTION
Fixes problem where loading modal doesn't close even when data is loaded correctly

  - [ ] Up to date with `main` branch
  - [ ] Branch name follows [guidelines](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md#feature-branching)
  - [ ] All PR Status checks are successful
  - [ ] Peer reviewed and approved

Any questions? See the [getting started guide](https://github.com/hackforla/311-data/blob/master/GETTING_STARTED.md)
