### PR TITLE
Parameterize year in socrata call; add local debug instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ Our mission is to create a user-friendly platform for anyone interested in explo
 - Run `npm start`
 - Visit http://localhost:5173
 
+### Debug locally using VSCode
+
+Your launch.json config should look something like this:
+
+```bash
+      "type": "chrome",
+      "request": "launch",
+      "name": "Debug in Chrome",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "/@fs/*": "/*",
+        "/src/*": "${workspaceFolder}/src/*"
+      },
+```
+
+- Run `npm start` in a terminal
+- Press F5 to start "Debug in Chrome". VSCode will open a Chrome window it controls. You can set breakpoints etc in VSCode.
+
 ### Run tests
 
 - Run `npm test`

--- a/src/utils/DataService.js
+++ b/src/utils/DataService.js
@@ -4,6 +4,7 @@ import moment from "moment";
 import ddbh from "@utils/duckDbHelpers.js";
 
 const dataResources = {
+  2026: "2cy6-i7zn",
   2025: "h73f-gn57",
   2024: "b7dx-7gc3",
   2019: "pvft-t768",
@@ -63,9 +64,11 @@ export async function getServiceRequestSocrata() {
   const dataLoadStartTime = performance.now();
 
   try {
-    // Fetch 2025 SR data through Socrata API
+    // Fetch current year SR data through Socrata API
+    const currentYear = String(new Date().getFullYear());
+    const currentYearFilename = `https://data.lacity.org/resource/${dataResources[currentYear]}.json`
     const response = await fetch(
-      "https://data.lacity.org/resource/h73f-gn57.json"
+      currentYearFilename
     );
     const unvalidatedSrs = await response.json();
 


### PR DESCRIPTION
Tested this locally; app runs with no errors, but as before, nothing appears on the map. But I wanted to get this change out to ensure we are getting the correct file from Socrata.
